### PR TITLE
feat(rate-limit): agregar throttler global y por endpoints críticos

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@nestjs/mapped-types": "*",
     "@nestjs/platform-express": "^11.0.1",
     "@nestjs/schedule": "^6.0.1",
+    "@nestjs/throttler": "^6.5.0",
     "@nestjs/typeorm": "^11.0.0",
     "axios": "^1.9.0",
     "class-transformer": "0.5.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       '@nestjs/schedule':
         specifier: ^6.0.1
         version: 6.1.3(@nestjs/common@11.1.21(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.21)
+      '@nestjs/throttler':
+        specifier: ^6.5.0
+        version: 6.5.0(@nestjs/common@11.1.21(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.21)(reflect-metadata@0.2.2)
       '@nestjs/typeorm':
         specifier: ^11.0.0
         version: 11.0.1(@nestjs/common@11.1.21(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.21)(reflect-metadata@0.2.2)(rxjs@7.8.2)(typeorm@0.3.29(mysql2@3.22.3(@types/node@22.19.19))(ts-node@10.9.2(@swc/core@1.15.33)(@types/node@22.19.19)(typescript@5.9.3)))
@@ -675,49 +678,42 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@napi-rs/nice-linux-arm64-musl@1.1.1':
     resolution: {integrity: sha512-+2Rzdb3nTIYZ0YJF43qf2twhqOCkiSrHx2Pg6DJaCPYhhaxbLcdlV8hCRMHghQ+EtZQWGNcS2xF4KxBhSGeutg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@napi-rs/nice-linux-ppc64-gnu@1.1.1':
     resolution: {integrity: sha512-4FS8oc0GeHpwvv4tKciKkw3Y4jKsL7FRhaOeiPei0X9T4Jd619wHNe4xCLmN2EMgZoeGg+Q7GY7BsvwKpL22Tg==}
     engines: {node: '>= 10'}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@napi-rs/nice-linux-riscv64-gnu@1.1.1':
     resolution: {integrity: sha512-HU0nw9uD4FO/oGCCk409tCi5IzIZpH2agE6nN4fqpwVlCn5BOq0MS1dXGjXaG17JaAvrlpV5ZeyZwSon10XOXw==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@napi-rs/nice-linux-s390x-gnu@1.1.1':
     resolution: {integrity: sha512-2YqKJWWl24EwrX0DzCQgPLKQBxYDdBxOHot1KWEq7aY2uYeX+Uvtv4I8xFVVygJDgf6/92h9N3Y43WPx8+PAgQ==}
     engines: {node: '>= 10'}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@napi-rs/nice-linux-x64-gnu@1.1.1':
     resolution: {integrity: sha512-/gaNz3R92t+dcrfCw/96pDopcmec7oCcAQ3l/M+Zxr82KT4DljD37CpgrnXV+pJC263JkW572pdbP3hP+KjcIg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@napi-rs/nice-linux-x64-musl@1.1.1':
     resolution: {integrity: sha512-xScCGnyj/oppsNPMnevsBe3pvNaoK7FGvMjT35riz9YdhB2WtTG47ZlbxtOLpjeO9SqqQ2J2igCmz6IJOD5JYw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@napi-rs/nice-openharmony-arm64@1.1.1':
     resolution: {integrity: sha512-6uJPRVwVCLDeoOaNyeiW0gp2kFIM4r7PL2MczdZQHkFi9gVlgm+Vn+V6nTWRcu856mJ2WjYJiumEajfSm7arPQ==}
@@ -844,6 +840,13 @@ packages:
       '@nestjs/platform-express':
         optional: true
 
+  '@nestjs/throttler@6.5.0':
+    resolution: {integrity: sha512-9j0ZRfH0QE1qyrj9JjIRDz5gQLPqq9yVC2nHsrosDVAfI5HHw08/aUAWx9DZLSdQf4HDkmhTTEGLrRFHENvchQ==}
+    peerDependencies:
+      '@nestjs/common': ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0
+      '@nestjs/core': ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0
+      reflect-metadata: ^0.1.13 || ^0.2.0
+
   '@nestjs/typeorm@11.0.1':
     resolution: {integrity: sha512-8rw/nKT0S+L+MkzgE9F2/mox7mAgsPlwfzmW9gsESN1lmQtIrVEfiiBwC2O8+guS1jBfQehJIdcdUj2OAp4VUQ==}
     peerDependencies:
@@ -935,42 +938,36 @@ packages:
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@swc/core-linux-arm64-musl@1.15.33':
     resolution: {integrity: sha512-il7tYM+CpUNzieQbwAjFT1P8zqAhmGWNAGhQZBnxurXZ0aNn+5nqYFTEUKNZl7QibtT0uQXzTZrNGHCIj6Y1Og==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@swc/core-linux-ppc64-gnu@1.15.33':
     resolution: {integrity: sha512-ZtNBwN0Z7CFj9Il0FcPaKdjgP7URyKu/3RfH46vq+0paOBqLj4NYldD6Qo//Duif/7IOtAraUfDOmp0PLAufog==}
     engines: {node: '>=10'}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@swc/core-linux-s390x-gnu@1.15.33':
     resolution: {integrity: sha512-De1IyajoOmhOYYjw/lx66bKlyDpHZTueqwpDrWgf5O7T6d1ODeJJO9/OqMBmrBQc5C+dNnlmIufHsp4QVCWufA==}
     engines: {node: '>=10'}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@swc/core-linux-x64-gnu@1.15.33':
     resolution: {integrity: sha512-mGTH0YxmUN+x6vRN/I6NOk5X0ogNktkwPnJ94IMvR7QjhRDwL0O8RXEDhyUM0YtwWrryBOqaJQBX4zruxEPRGw==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@swc/core-linux-x64-musl@1.15.33':
     resolution: {integrity: sha512-hj628ZkSEJf6zMf5VMbYrG2O6QqyTIp2qwY6VlCjvIa9lAEZ5c2lfPblCLVGYubTeLJDxadLB/CxqQYOQABeEQ==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@swc/core-win32-arm64-msvc@1.15.33':
     resolution: {integrity: sha512-GV2oohtN2/5+KSccl86VULu3aT+LrISC8uzgSq0FRnikpD+Zwc+sBlXmoKQ+Db6jI57ITUOIB8jRkdGMABC29g==}
@@ -4582,6 +4579,12 @@ snapshots:
       tslib: 2.8.1
     optionalDependencies:
       '@nestjs/platform-express': 11.1.21(@nestjs/common@11.1.21(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.21)
+
+  '@nestjs/throttler@6.5.0(@nestjs/common@11.1.21(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.21)(reflect-metadata@0.2.2)':
+    dependencies:
+      '@nestjs/common': 11.1.21(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/core': 11.1.21(@nestjs/common@11.1.21(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.21)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      reflect-metadata: 0.2.2
 
   '@nestjs/typeorm@11.0.1(@nestjs/common@11.1.21(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.21)(reflect-metadata@0.2.2)(rxjs@7.8.2)(typeorm@0.3.29(mysql2@3.22.3(@types/node@22.19.19))(ts-node@10.9.2(@swc/core@1.15.33)(@types/node@22.19.19)(typescript@5.9.3)))':
     dependencies:

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,6 +1,8 @@
 import { Module } from '@nestjs/common';
 import { ScheduleModule } from '@nestjs/schedule';
 import { ConfigModule, ConfigService } from '@nestjs/config';
+import { APP_GUARD } from '@nestjs/core';
+import { ThrottlerGuard, ThrottlerModule } from '@nestjs/throttler';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
 import { StkItemModule } from './stk-item/stk-item.module';
@@ -25,11 +27,50 @@ import { VtaCobroModule } from './vta-cobro/vta-cobro.module';
 import { VtaCobroFacturaModule } from './vta-cobro-factura/vta-cobro-factura.module';
 import { VtaCobroMedioModule } from './vta-cobro-medio/vta-cobro-medio.module';
 import { ColorsModule } from './colors/colors.module';
+import {
+  DEFAULT_RATE_LIMIT_GLOBAL,
+  DEFAULT_RATE_LIMIT_TTL_MS,
+  RATE_LIMIT_GLOBAL,
+  RATE_LIMIT_TTL_MS,
+} from './common/rate-limit/rate-limit.config';
+
+function getConfiguredRateLimit(
+  config: ConfigService,
+  name: string,
+  defaultValue: number,
+): number {
+  const value = Number(config.get<string>(name));
+
+  if (!Number.isFinite(value) || value <= 0) {
+    return defaultValue;
+  }
+
+  return value;
+}
 
 @Module({
   imports: [
     // Cargar variables de entorno de forma global
     ConfigModule.forRoot({ isGlobal: true }),
+
+    ThrottlerModule.forRootAsync({
+      imports: [ConfigModule],
+      useFactory: (config: ConfigService) => [
+        {
+          ttl: getConfiguredRateLimit(
+            config,
+            RATE_LIMIT_TTL_MS,
+            DEFAULT_RATE_LIMIT_TTL_MS,
+          ),
+          limit: getConfiguredRateLimit(
+            config,
+            RATE_LIMIT_GLOBAL,
+            DEFAULT_RATE_LIMIT_GLOBAL,
+          ),
+        },
+      ],
+      inject: [ConfigService],
+    }),
 
     // 🟡 Conexión Nacional Software (wetechv2)
     TypeOrmModule.forRootAsync({
@@ -89,6 +130,12 @@ import { ColorsModule } from './colors/colors.module';
     VtaCobroFacturaModule,
     VtaCobroMedioModule,
     ColorsModule,
+  ],
+  providers: [
+    {
+      provide: APP_GUARD,
+      useClass: ThrottlerGuard,
+    },
   ],
 })
 export class AppModule {}

--- a/src/common/rate-limit/rate-limit.config.ts
+++ b/src/common/rate-limit/rate-limit.config.ts
@@ -1,0 +1,34 @@
+import { ExecutionContext } from '@nestjs/common';
+
+export const RATE_LIMIT_TTL_MS = 'RATE_LIMIT_TTL_MS';
+export const RATE_LIMIT_GLOBAL = 'RATE_LIMIT_GLOBAL';
+export const RATE_LIMIT_PEDIDO_CREATE = 'RATE_LIMIT_PEDIDO_CREATE';
+export const RATE_LIMIT_NAVE_WEBHOOK = 'RATE_LIMIT_NAVE_WEBHOOK';
+export const RATE_LIMIT_MAPS_DISTANCE = 'RATE_LIMIT_MAPS_DISTANCE';
+
+export const DEFAULT_RATE_LIMIT_TTL_MS = 60000;
+export const DEFAULT_RATE_LIMIT_GLOBAL = 300;
+export const DEFAULT_RATE_LIMIT_PEDIDO_CREATE = 30;
+export const DEFAULT_RATE_LIMIT_NAVE_WEBHOOK = 120;
+export const DEFAULT_RATE_LIMIT_NAVE_WEBHOOK_TEST = 60;
+export const DEFAULT_RATE_LIMIT_MAPS_DISTANCE = 60;
+
+export function getRateLimitValue(
+  name: string,
+  defaultValue: number,
+): number {
+  const value = Number(process.env[name]);
+
+  if (!Number.isFinite(value) || value <= 0) {
+    return defaultValue;
+  }
+
+  return value;
+}
+
+export function rateLimitValue(
+  name: string,
+  defaultValue: number,
+): (_context: ExecutionContext) => number {
+  return () => getRateLimitValue(name, defaultValue);
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,6 +11,7 @@ setDefaultResultOrder('ipv4first');
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+  app.getHttpAdapter().getInstance().set('trust proxy', 1);
 
   const allowedOrigins = process.env.ALLOWED_ORIGINS
     ? process.env.ALLOWED_ORIGINS.split(',')

--- a/src/maps/maps.controller.ts
+++ b/src/maps/maps.controller.ts
@@ -1,12 +1,29 @@
 import { Controller, Post, Body } from '@nestjs/common';
 import { MapsService } from './maps.service';
 import { GetDistanceDto } from './dto/get-distance.dto';
+import { Throttle } from '@nestjs/throttler';
+import {
+  DEFAULT_RATE_LIMIT_MAPS_DISTANCE,
+  DEFAULT_RATE_LIMIT_TTL_MS,
+  RATE_LIMIT_MAPS_DISTANCE,
+  RATE_LIMIT_TTL_MS,
+  rateLimitValue,
+} from '../common/rate-limit/rate-limit.config';
 
 @Controller('maps')
 export class MapsController {
   constructor(private readonly mapsService: MapsService) {}
 
   @Post('distance')
+  @Throttle({
+    default: {
+      ttl: rateLimitValue(RATE_LIMIT_TTL_MS, DEFAULT_RATE_LIMIT_TTL_MS),
+      limit: rateLimitValue(
+        RATE_LIMIT_MAPS_DISTANCE,
+        DEFAULT_RATE_LIMIT_MAPS_DISTANCE,
+      ),
+    },
+  })
   async getDistance(@Body() dto: GetDistanceDto) {
     return await this.mapsService.getDistanceToDestination(dto.address, dto.city);
   }

--- a/src/pedido/pedido.controller.ts
+++ b/src/pedido/pedido.controller.ts
@@ -16,6 +16,17 @@ import { CreatePedidoDto } from './dto/create-pedido.dto';
 import { ApiTokenGuard } from '../common/guards/api-token.guard';
 import { AuthType } from '../common/decorators/auth-type.decorator';
 import { GetPedidosDashboardDto } from './dto/get-pedidos-dashboard.dto';
+import { Throttle } from '@nestjs/throttler';
+import {
+  DEFAULT_RATE_LIMIT_NAVE_WEBHOOK,
+  DEFAULT_RATE_LIMIT_NAVE_WEBHOOK_TEST,
+  DEFAULT_RATE_LIMIT_PEDIDO_CREATE,
+  DEFAULT_RATE_LIMIT_TTL_MS,
+  RATE_LIMIT_NAVE_WEBHOOK,
+  RATE_LIMIT_PEDIDO_CREATE,
+  RATE_LIMIT_TTL_MS,
+  rateLimitValue,
+} from '../common/rate-limit/rate-limit.config';
 
 @Controller('pedido')
 @UseGuards(ApiTokenGuard)
@@ -23,11 +34,29 @@ export class PedidoController {
   constructor(private readonly pedidoService: PedidoService) {}
 
   @Post()
+  @Throttle({
+    default: {
+      ttl: rateLimitValue(RATE_LIMIT_TTL_MS, DEFAULT_RATE_LIMIT_TTL_MS),
+      limit: rateLimitValue(
+        RATE_LIMIT_PEDIDO_CREATE,
+        DEFAULT_RATE_LIMIT_PEDIDO_CREATE,
+      ),
+    },
+  })
   async crear(@Body() dto: CreatePedidoDto) {
     return this.pedidoService.crear(dto);
   }
 
   @Post('nave-webhook')
+  @Throttle({
+    default: {
+      ttl: rateLimitValue(RATE_LIMIT_TTL_MS, DEFAULT_RATE_LIMIT_TTL_MS),
+      limit: rateLimitValue(
+        RATE_LIMIT_NAVE_WEBHOOK,
+        DEFAULT_RATE_LIMIT_NAVE_WEBHOOK,
+      ),
+    },
+  })
   @AuthType('public')
   @HttpCode(HttpStatus.OK)
   async recibirWebhook(@Body() body: any) {
@@ -42,6 +71,15 @@ export class PedidoController {
   }
 
   @Post('nave-webhook/test')
+  @Throttle({
+    default: {
+      ttl: rateLimitValue(RATE_LIMIT_TTL_MS, DEFAULT_RATE_LIMIT_TTL_MS),
+      limit: rateLimitValue(
+        RATE_LIMIT_NAVE_WEBHOOK,
+        DEFAULT_RATE_LIMIT_NAVE_WEBHOOK_TEST,
+      ),
+    },
+  })
   @AuthType('public')
   @HttpCode(HttpStatus.OK)
   async testWebhook(@Body() body: any) {

--- a/test/rate-limit.e2e-spec.ts
+++ b/test/rate-limit.e2e-spec.ts
@@ -1,0 +1,87 @@
+import {
+  Controller,
+  HttpCode,
+  HttpStatus,
+  INestApplication,
+  Post,
+} from '@nestjs/common';
+import { APP_GUARD, Reflector } from '@nestjs/core';
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigModule, ConfigService } from '@nestjs/config';
+import { Throttle, ThrottlerGuard, ThrottlerModule } from '@nestjs/throttler';
+import * as request from 'supertest';
+import { App } from 'supertest/types';
+import { ApiTokenGuard } from '../src/common/guards/api-token.guard';
+import { AuthType } from '../src/common/decorators/auth-type.decorator';
+
+@Controller('rate-limit-test')
+class RateLimitTestController {
+  @Post('ok')
+  @AuthType('public')
+  @HttpCode(HttpStatus.OK)
+  ok() {
+    return { ok: true };
+  }
+
+  @Post('limited')
+  @AuthType('public')
+  @Throttle({ default: { limit: 2, ttl: 60000 } })
+  @HttpCode(HttpStatus.OK)
+  limited() {
+    return { ok: true };
+  }
+}
+
+describe('Rate limit (e2e)', () => {
+  let app: INestApplication<App>;
+
+  beforeEach(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [
+        ConfigModule.forRoot({ isGlobal: true }),
+        ThrottlerModule.forRoot([
+          {
+            ttl: 60000,
+            limit: 100,
+          },
+        ]),
+      ],
+      controllers: [RateLimitTestController],
+      providers: [
+        {
+          provide: APP_GUARD,
+          useClass: ThrottlerGuard,
+        },
+        {
+          provide: APP_GUARD,
+          useFactory: (reflector: Reflector, configService: ConfigService) =>
+            new ApiTokenGuard(reflector, configService),
+          inject: [Reflector, ConfigService],
+        },
+      ],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    await app.init();
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('allows requests within the configured limit', async () => {
+    await request(app.getHttpServer()).post('/rate-limit-test/ok').expect(200);
+  });
+
+  it('returns 429 when a route limit is exceeded', async () => {
+    const server = app.getHttpServer();
+
+    await request(server).post('/rate-limit-test/limited').expect(200);
+    await request(server).post('/rate-limit-test/limited').expect(200);
+    await request(server).post('/rate-limit-test/limited').expect(429);
+  });
+
+  it('keeps public webhook-style routes accessible without Authorization', async () => {
+    await request(app.getHttpServer()).post('/rate-limit-test/ok').expect(200);
+  });
+});


### PR DESCRIPTION
- Instalar @nestjs/throttler
- Configurar rate limiting global desde variables de entorno
- Habilitar trust proxy para obtener IP real detrás de proxies
- Aplicar límites específicos en /pedido (crear y webhooks) y /maps/distance