### PR TITLE
feat(pedido): envío gratis automático para pedidos 'shipping' con pes…

### DIFF
--- a/src/pedido/pedido.service.spec.ts
+++ b/src/pedido/pedido.service.spec.ts
@@ -332,6 +332,120 @@ describe('PedidoService recalculo de importes', () => {
     );
   });
 
+  it('deja envio gratis para shipping desde 10 kg aunque reciba costo de envio', async () => {
+    stkItemRepo.findOne.mockResolvedValue(
+      itemConPrecio(
+        'ITEM-10KG',
+        '100',
+        'PES',
+        '1',
+        null,
+        'Producto 1kg',
+      ),
+    );
+
+    const dto = dtoBase({
+      tipo_envio: 'shipping',
+      costo_envio: 250,
+      total: 1000,
+      productos: [
+        {
+          nombre: 'ITEM-10KG',
+          cantidad: 10,
+          precio_unitario: 100,
+          subtotal: 1000,
+        },
+      ],
+    });
+
+    const { pedido } = await service.crear(dto);
+
+    expect(pedido.costo_envio).toBe(0);
+    expect(pedido.total).toBe(1000);
+    expect(service.generarIntencionDePago).toHaveBeenCalledWith(
+      expect.objectContaining({
+        costo_envio: 0,
+        total: 1000,
+      }),
+    );
+  });
+
+  it('conserva costo de envio para shipping con menos de 10 kg', async () => {
+    stkItemRepo.findOne.mockResolvedValue(
+      itemConPrecio(
+        'ITEM-9KG',
+        '100',
+        'PES',
+        '1',
+        null,
+        'Producto 1kg',
+      ),
+    );
+
+    const dto = dtoBase({
+      tipo_envio: 'shipping',
+      costo_envio: 250,
+      total: 1150,
+      productos: [
+        {
+          nombre: 'ITEM-9KG',
+          cantidad: 9,
+          precio_unitario: 100,
+          subtotal: 900,
+        },
+      ],
+    });
+
+    const { pedido } = await service.crear(dto);
+
+    expect(pedido.costo_envio).toBe(250);
+    expect(pedido.total).toBe(1150);
+    expect(service.generarIntencionDePago).toHaveBeenCalledWith(
+      expect.objectContaining({
+        costo_envio: 250,
+        total: 1150,
+      }),
+    );
+  });
+
+  it('no aplica envio gratis por peso para pickup', async () => {
+    stkItemRepo.findOne.mockResolvedValue(
+      itemConPrecio(
+        'ITEM-PICKUP-10KG',
+        '100',
+        'PES',
+        '1',
+        null,
+        'Producto 1kg',
+      ),
+    );
+
+    const dto = dtoBase({
+      tipo_envio: 'pickup',
+      costo_envio: 250,
+      total: 1250,
+      productos: [
+        {
+          nombre: 'ITEM-PICKUP-10KG',
+          cantidad: 10,
+          precio_unitario: 100,
+          subtotal: 1000,
+        },
+      ],
+    });
+
+    const { pedido } = await service.crear(dto);
+
+    expect(pedido.costo_envio).toBe(250);
+    expect(pedido.total).toBe(1250);
+    expect(service.generarIntencionDePago).toHaveBeenCalledWith(
+      expect.objectContaining({
+        costo_envio: 250,
+        total: 1250,
+      }),
+    );
+  });
+
   it('redondea el descuento de cupon normal al peso', async () => {
     stkItemRepo.findOne.mockResolvedValue(itemConPrecio('ITEM-2B', '101'));
     cuponService.resolverPorcentajePorModalidad.mockResolvedValue({

--- a/src/pedido/pedido.service.ts
+++ b/src/pedido/pedido.service.ts
@@ -35,6 +35,8 @@ import {
 
 type PedidoMetodoPago = 'online' | 'transfer';
 
+const FREE_SHIPPING_MIN_WEIGHT_KG = 10;
+
 interface PedidoProductoCalculado {
   nombre: string;
   cantidad: number;
@@ -126,6 +128,7 @@ export class PedidoService {
     const productosCalculados: PedidoProductoCalculado[] = [];
     const productosValidados: PedidoItem[] = [];
     const diferenciasProductos: PedidoProductoMismatch[] = [];
+    let pesoTotalKg = 0;
 
     for (const producto of dto.productos) {
       const item = await this.stkItemRepo.findOne({
@@ -141,6 +144,7 @@ export class PedidoService {
 
       const cantidad = this.obtenerCantidadProducto(producto);
       const peso = parseProductWeightFromDescription(item.descripcion);
+      pesoTotalKg += (peso ?? 0) * cantidad;
       const productoDescuento = {
         id: item.id,
         category: item.grupo,
@@ -205,14 +209,19 @@ export class PedidoService {
         0,
       ),
     );
+    const costoEnvioCalculado = this.calcularCostoEnvioPedido(
+      dto,
+      pesoTotalKg,
+    );
     const totalCalculado = this.redondearPrecio(
-      productosNetos + Number(dto.costo_envio ?? 0),
+      productosNetos + costoEnvioCalculado,
     );
 
     this.validarTotalesRecibidos(dto, {
       total: totalCalculado,
       descuento_cupon: descuentoCupon,
       productos: diferenciasProductos,
+      costo_envio: costoEnvioCalculado,
     });
 
     for (const p of productosValidados) {
@@ -244,7 +253,7 @@ export class PedidoService {
       cliente_mail: dto.email,
       external_id: externalId,
       total: totalCalculado,
-      costo_envio: dto.costo_envio,
+      costo_envio: costoEnvioCalculado,
       descuento_cupon: descuentoCupon || undefined,
       codigo_cupon: dto.codigo_cupon ?? undefined,
       delivery_method: dto.tipo_envio,
@@ -315,6 +324,7 @@ export class PedidoService {
       const naveUrl = await this.generarIntencionDePago({
         ...dto,
         total: totalCalculado,
+        costo_envio: costoEnvioCalculado,
         descuento_cupon: descuentoCupon,
         metodo_pago: metodoPago,
         productos: productosValidados.map((producto) => ({
@@ -1169,6 +1179,20 @@ export class PedidoService {
     return Number(Math.round(valor).toFixed(2));
   }
 
+  private calcularCostoEnvioPedido(
+    dto: CreatePedidoDto,
+    pesoTotalKg: number,
+  ): number {
+    if (
+      dto.tipo_envio === 'shipping' &&
+      pesoTotalKg >= FREE_SHIPPING_MIN_WEIGHT_KG
+    ) {
+      return 0;
+    }
+
+    return this.redondearPrecio(Number(dto.costo_envio ?? 0));
+  }
+
   private calcularProductoPedido(
     producto: CreatePedidoDto['productos'][number],
     item: StkItem,
@@ -1354,6 +1378,7 @@ export class PedidoService {
       total: number;
       descuento_cupon: number;
       productos: PedidoProductoMismatch[];
+      costo_envio: number;
     },
   ): void {
     const diferencias: {
@@ -1402,7 +1427,7 @@ export class PedidoService {
         cliente_cuit: dto.cliente_cuit,
         metodo_pago: dto.metodo_pago ?? 'online',
         codigo_cupon: dto.codigo_cupon,
-        costo_envio: dto.costo_envio,
+        costo_envio: calculado.costo_envio,
         expected: diferencias.expected,
         received: diferencias.received,
         productos: diferencias.productos,


### PR DESCRIPTION
…o ≥ 10 kg

- Calcular costo de envío del lado del servidor según peso total y método
- Aplicar envío gratis (costo_envio = 0) si tipo_envio = 'shipping' y peso total ≥ 10 kg
- Agregar constante FREE_SHIPPING_MIN_WEIGHT_KG = 10
- Incluir validación en validarTotalesRecibidos con costo_envio calculado
- Agregar tests unitarios:
  - Envío gratis desde 10 kg en shipping
  - Mantener costo de envío si menos de 10 kg
  - No aplicar gratis para pickup