### PR TITLE
feat(pedido): aplicar descuento por producto solo en pagos transferencia

### DIFF
--- a/src/pedido/pedido.service.spec.ts
+++ b/src/pedido/pedido.service.spec.ts
@@ -210,15 +210,20 @@ describe('PedidoService recalculo de importes', () => {
     expect(pedido.total).toBe(21);
   });
 
-  it('mantiene descuento de filamento si es mayor que el cupon y excluye envio de la base', async () => {
+  it('mantiene descuento de filamento en transferencia si es mayor que el cupon y excluye envio de la base', async () => {
     stkItemRepo.findOne.mockResolvedValue(
       itemConPrecio('ITEM-2', '101', 'PES', '1', 'FILAMENTOS'),
     );
     cuponService.resolverPorcentajePorModalidad.mockResolvedValue({
       porcentajeAplicado: 10,
     });
+    vtaComprobanteService.crearDesdePedido.mockResolvedValue({
+      tipo: 'FX',
+      comprobante: '0003',
+    });
 
     const dto = dtoBase({
+      metodo_pago: 'transfer',
       codigo_cupon: 'CUPON10',
       descuento_cupon: 0,
       costo_envio: 50,
@@ -237,7 +242,7 @@ describe('PedidoService recalculo de importes', () => {
 
     expect(cuponService.resolverPorcentajePorModalidad).toHaveBeenCalledWith(
       'CUPON10',
-      'TARJETA',
+      'CUENTA',
     );
     expect(pedido.productos[0].precio_unitario).toBe(86);
     expect(pedido.productos[0].ajuste_porcentaje).toBe(15);
@@ -330,6 +335,41 @@ describe('PedidoService recalculo de importes', () => {
         ],
       }),
     );
+  });
+
+  it('no aplica descuento base de filamento para pagos online', async () => {
+    stkItemRepo.findOne.mockResolvedValue(
+      itemConPrecio(
+        'GL-PLA-1KG-VAIN',
+        '21175',
+        'PES',
+        '1',
+        'FILAMENTOS',
+        'Filamento PLA 1kg vainilla',
+      ),
+    );
+
+    const dto = dtoBase({
+      metodo_pago: 'online',
+      total: 25174,
+      costo_envio: 3999,
+      productos: [
+        {
+          nombre: 'GL-PLA-1KG-VAIN',
+          cantidad: 1,
+          precio_unitario: 21175,
+          subtotal: 21175,
+          ajuste_porcentaje: 0,
+        },
+      ],
+    });
+
+    const { pedido } = await service.crear(dto);
+
+    expect(pedido.productos[0].precio_unitario).toBe(21175);
+    expect(pedido.productos[0].ajuste_porcentaje).toBeNull();
+    expect(pedido.costo_envio).toBe(3999);
+    expect(pedido.total).toBe(25174);
   });
 
   it('deja envio gratis para shipping desde 10 kg aunque reciba costo de envio', async () => {
@@ -657,8 +697,13 @@ describe('PedidoService recalculo de importes', () => {
           'Filamento PLA 500g blanco',
         ),
       );
+    vtaComprobanteService.crearDesdePedido.mockResolvedValue({
+      tipo: 'FX',
+      comprobante: '0004',
+    });
 
     const dto = dtoBase({
+      metodo_pago: 'transfer',
       total: undefined,
       productos: [
         {
@@ -736,6 +781,16 @@ describe('PedidoService recalculo de importes', () => {
         ],
       }),
       'Los importes recibidos no coinciden con el calculo del servidor.',
+    );
+    expect(mailerService.enviarCorreo).toHaveBeenCalledWith(
+      'virtual.hache@gmail.com',
+      'Alerta WeTech: importes no coinciden',
+      expect.stringContaining('ERR_ORDER_TOTAL_MISMATCH'),
+    );
+    expect(mailerService.enviarCorreo).toHaveBeenCalledWith(
+      'virtual.hache@gmail.com',
+      'Alerta WeTech: importes no coinciden',
+      expect.stringContaining('&quot;total&quot;: 90'),
     );
     expect(stockService.reservarStock).not.toHaveBeenCalled();
   });

--- a/src/pedido/pedido.service.ts
+++ b/src/pedido/pedido.service.ts
@@ -36,6 +36,7 @@ import {
 type PedidoMetodoPago = 'online' | 'transfer';
 
 const FREE_SHIPPING_MIN_WEIGHT_KG = 10;
+const ALERTA_IMPORTES_EMAIL = 'virtual.hache@gmail.com';
 
 interface PedidoProductoCalculado {
   nombre: string;
@@ -179,6 +180,7 @@ export class PedidoService {
         producto,
         item,
         porcentajeCupon,
+        metodoPago,
         peso,
         cantidadParaDescuento,
       );
@@ -217,7 +219,7 @@ export class PedidoService {
       productosNetos + costoEnvioCalculado,
     );
 
-    this.validarTotalesRecibidos(dto, {
+    await this.validarTotalesRecibidos(dto, {
       total: totalCalculado,
       descuento_cupon: descuentoCupon,
       productos: diferenciasProductos,
@@ -1197,6 +1199,7 @@ export class PedidoService {
     producto: CreatePedidoDto['productos'][number],
     item: StkItem,
     porcentajeCupon: number,
+    metodoPago: PedidoMetodoPago,
     peso?: number,
     cantidadParaDescuento?: number,
   ): PedidoProductoCalculado {
@@ -1206,13 +1209,19 @@ export class PedidoService {
       id: item.id,
       category: item.grupo,
     };
-    const descuentoProductoPorcentaje = this.parsearPorcentajeDescuento(
-      getDiscountPercentageForProduct(
-        productoDescuento,
-        cantidadParaDescuento ?? cantidad,
-        peso ?? parseProductWeightFromDescription(item.descripcion),
-      ),
-    );
+    const pesoProducto = peso ?? parseProductWeightFromDescription(item.descripcion);
+    const aplicaDescuentoProducto =
+      metodoPago === 'transfer' ||
+      isEligibleForQuantityDiscount(productoDescuento, pesoProducto ?? 0);
+    const descuentoProductoPorcentaje = aplicaDescuentoProducto
+      ? this.parsearPorcentajeDescuento(
+          getDiscountPercentageForProduct(
+            productoDescuento,
+            cantidadParaDescuento ?? cantidad,
+            pesoProducto,
+          ),
+        )
+      : 0;
     const descuentoPorcentaje = Math.max(
       descuentoProductoPorcentaje,
       porcentajeCupon,
@@ -1372,7 +1381,7 @@ export class PedidoService {
     return porcentaje;
   }
 
-  private validarTotalesRecibidos(
+  private async validarTotalesRecibidos(
     dto: CreatePedidoDto,
     calculado: {
       total: number;
@@ -1380,7 +1389,7 @@ export class PedidoService {
       productos: PedidoProductoMismatch[];
       costo_envio: number;
     },
-  ): void {
+  ): Promise<void> {
     const diferencias: {
       expected: {
         total?: number;
@@ -1421,26 +1430,32 @@ export class PedidoService {
       return;
     }
 
+    const logImportes = {
+      code: 'ERR_ORDER_TOTAL_MISMATCH',
+      cliente_nombre: dto.cliente_nombre,
+      cliente_cuit: dto.cliente_cuit,
+      cliente_mail: dto.email ?? dto.cliente_mail,
+      telefono: dto.telefono ?? dto.mobile,
+      metodo_pago: dto.metodo_pago ?? 'online',
+      codigo_cupon: dto.codigo_cupon,
+      costo_envio: calculado.costo_envio,
+      expected: diferencias.expected,
+      received: diferencias.received,
+      productos: diferencias.productos,
+      productos_recibidos: dto.productos.map((producto) => ({
+        nombre: producto.nombre,
+        cantidad: producto.cantidad,
+        precio_unitario: producto.precio_unitario,
+        subtotal: producto.subtotal,
+        ajuste_porcentaje: producto.ajuste_porcentaje,
+      })),
+    };
+
     this.logger.warn(
-      {
-        code: 'ERR_ORDER_TOTAL_MISMATCH',
-        cliente_cuit: dto.cliente_cuit,
-        metodo_pago: dto.metodo_pago ?? 'online',
-        codigo_cupon: dto.codigo_cupon,
-        costo_envio: calculado.costo_envio,
-        expected: diferencias.expected,
-        received: diferencias.received,
-        productos: diferencias.productos,
-        productos_recibidos: dto.productos.map((producto) => ({
-          nombre: producto.nombre,
-          cantidad: producto.cantidad,
-          precio_unitario: producto.precio_unitario,
-          subtotal: producto.subtotal,
-          ajuste_porcentaje: producto.ajuste_porcentaje,
-        })),
-      },
+      logImportes,
       'Los importes recibidos no coinciden con el calculo del servidor.',
     );
+    await this.enviarAlertaImportesNoCoinciden(logImportes);
 
     throw new BadRequestException({
       code: 'ERR_ORDER_TOTAL_MISMATCH',
@@ -1449,6 +1464,39 @@ export class PedidoService {
       received: diferencias.received,
       productos: diferencias.productos,
     });
+  }
+
+  private async enviarAlertaImportesNoCoinciden(
+    logImportes: Record<string, unknown>,
+  ): Promise<void> {
+    const logJson = JSON.stringify(logImportes, null, 2);
+    const html = `
+      <h2>Alerta: importes no coinciden</h2>
+      <p>Se rechazo un pedido porque los importes recibidos no coinciden con el calculo del servidor.</p>
+      <pre style="white-space: pre-wrap; font-family: monospace; background: #f5f5f5; padding: 12px; border: 1px solid #ddd;">${this.escapeHtml(logJson)}</pre>
+    `;
+
+    try {
+      await this.mailerService.enviarCorreo(
+        ALERTA_IMPORTES_EMAIL,
+        'Alerta WeTech: importes no coinciden',
+        html,
+      );
+    } catch (error) {
+      this.logger.error(
+        'No se pudo enviar alerta de importes no coincidentes',
+        error instanceof Error ? error.stack : String(error),
+      );
+    }
+  }
+
+  private escapeHtml(value: string): string {
+    return value
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#039;');
   }
 
   private montosIguales(


### PR DESCRIPTION
- Calcular descuento de producto (filamento) solo si método de pago es 'transfer' o aplica descuento por cantidad
- Para pagos 'online', precio_unitario y ajuste_porcentaje se mantienen sin descuento base
- Agregar alerta por email (virtual.hache@gmail.com) cuando hay diferencias de importes
- Mejorar logging y enviar detalle estructurado en HTML
- Actualizar tests: nuevo test para pago online sin descuento, ajustar test de transferencia con cupón