### PR TITLE
feat(pedido): tratar producto 'ENV-*' como costo de envío sin afectar…

### DIFF
--- a/src/pedido/pedido.service.spec.ts
+++ b/src/pedido/pedido.service.spec.ts
@@ -448,6 +448,110 @@ describe('PedidoService recalculo de importes', () => {
     );
   });
 
+  it('usa el producto ENV como costo de envio sin duplicarlo en el total', async () => {
+    stkItemRepo.findOne
+      .mockResolvedValueOnce(
+        itemConPrecio(
+          'GL-PLA-1KG-VAIN',
+          '21175',
+          'PES',
+          '1',
+          'FILAMENTOS',
+          'Filamento PLA 1kg vainilla',
+        ),
+      )
+      .mockResolvedValueOnce(
+        itemConPrecio(
+          'ENV-07K-GM-DELIVERY',
+          '3999',
+          'PES',
+          '1',
+          null,
+          'Envio delivery',
+        ),
+      );
+
+    const dto = dtoBase({
+      tipo_envio: 'shipping',
+      costo_envio: 3999,
+      total: 25174,
+      productos: [
+        {
+          nombre: 'GL-PLA-1KG-VAIN',
+          cantidad: 1,
+          precio_unitario: 21175,
+          subtotal: 21175,
+        },
+        {
+          nombre: 'ENV-07K-GM-DELIVERY',
+          cantidad: 1,
+          precio_unitario: 3999,
+          subtotal: 3999,
+        },
+      ],
+    });
+
+    const { pedido } = await service.crear(dto);
+
+    expect(pedido.costo_envio).toBe(3999);
+    expect(pedido.total).toBe(25174);
+    expect(service.generarIntencionDePago).toHaveBeenCalledWith(
+      expect.objectContaining({
+        costo_envio: 3999,
+        total: 25174,
+      }),
+    );
+  });
+
+  it('no cuenta el producto ENV para envio gratis por peso', async () => {
+    stkItemRepo.findOne
+      .mockResolvedValueOnce(
+        itemConPrecio(
+          'ITEM-9KG',
+          '100',
+          'PES',
+          '1',
+          null,
+          'Producto 1kg',
+        ),
+      )
+      .mockResolvedValueOnce(
+        itemConPrecio(
+          'ENV-07K-GM-DELIVERY',
+          '3999',
+          'PES',
+          '1',
+          null,
+          'Envio 7kg delivery',
+        ),
+      );
+
+    const dto = dtoBase({
+      tipo_envio: 'shipping',
+      costo_envio: 3999,
+      total: 4899,
+      productos: [
+        {
+          nombre: 'ITEM-9KG',
+          cantidad: 9,
+          precio_unitario: 100,
+          subtotal: 900,
+        },
+        {
+          nombre: 'ENV-07K-GM-DELIVERY',
+          cantidad: 1,
+          precio_unitario: 3999,
+          subtotal: 3999,
+        },
+      ],
+    });
+
+    const { pedido } = await service.crear(dto);
+
+    expect(pedido.costo_envio).toBe(3999);
+    expect(pedido.total).toBe(4899);
+  });
+
   it('no aplica envio gratis por peso para pickup', async () => {
     stkItemRepo.findOne.mockResolvedValue(
       itemConPrecio(

--- a/src/pedido/pedido.service.ts
+++ b/src/pedido/pedido.service.ts
@@ -64,6 +64,7 @@ interface PedidoProductoPrecargado {
   producto: CreatePedidoDto['productos'][number];
   item: StkItem;
   peso?: number;
+  esProductoEnvio: boolean;
   aplicaDescuentoDiferencialPorCantidad: boolean;
 }
 
@@ -144,16 +145,20 @@ export class PedidoService {
       }
 
       const cantidad = this.obtenerCantidadProducto(producto);
-      const peso = parseProductWeightFromDescription(item.descripcion);
-      pesoTotalKg += (peso ?? 0) * cantidad;
+      const esProductoEnvio = this.esProductoEnvio(producto.nombre);
+      const peso = esProductoEnvio
+        ? undefined
+        : parseProductWeightFromDescription(item.descripcion);
+      if (!esProductoEnvio) {
+        pesoTotalKg += (peso ?? 0) * cantidad;
+      }
       const productoDescuento = {
         id: item.id,
         category: item.grupo,
       };
-      const aplicaDescuentoDiferencialPorCantidad = isEligibleForQuantityDiscount(
-        productoDescuento,
-        peso ?? 0,
-      );
+      const aplicaDescuentoDiferencialPorCantidad =
+        !esProductoEnvio &&
+        isEligibleForQuantityDiscount(productoDescuento, peso ?? 0);
 
       if (aplicaDescuentoDiferencialPorCantidad) {
         cantidadTotalDescuentoDiferencial += cantidad;
@@ -163,6 +168,7 @@ export class PedidoService {
         producto,
         item,
         peso,
+        esProductoEnvio,
         aplicaDescuentoDiferencialPorCantidad,
       });
     }
@@ -171,6 +177,7 @@ export class PedidoService {
       producto,
       item,
       peso,
+      esProductoEnvio,
       aplicaDescuentoDiferencialPorCantidad,
     } of productosPrecargados) {
       const cantidadParaDescuento = aplicaDescuentoDiferencialPorCantidad
@@ -183,6 +190,7 @@ export class PedidoService {
         metodoPago,
         peso,
         cantidadParaDescuento,
+        esProductoEnvio,
       );
       const diferenciaProducto = this.obtenerDiferenciaProducto(
         producto,
@@ -211,12 +219,16 @@ export class PedidoService {
         0,
       ),
     );
-    const costoEnvioCalculado = this.calcularCostoEnvioPedido(
-      dto,
-      pesoTotalKg,
-    );
+    const costoEnvioDesdeProducto =
+      this.obtenerCostoEnvioDesdeProductos(productosValidados);
+    const costoEnvioCalculado =
+      costoEnvioDesdeProducto ??
+      this.calcularCostoEnvioPedido(dto, pesoTotalKg);
+    const costoEnvioAdicional = costoEnvioDesdeProducto == null
+      ? costoEnvioCalculado
+      : 0;
     const totalCalculado = this.redondearPrecio(
-      productosNetos + costoEnvioCalculado,
+      productosNetos + costoEnvioAdicional,
     );
 
     await this.validarTotalesRecibidos(dto, {
@@ -1195,6 +1207,18 @@ export class PedidoService {
     return this.redondearPrecio(Number(dto.costo_envio ?? 0));
   }
 
+  private esProductoEnvio(nombre?: string | null): boolean {
+    return /^ENV-\d+K-GM-DELIVERY$/i.test(String(nombre ?? ''));
+  }
+
+  private obtenerCostoEnvioDesdeProductos(productos: PedidoItem[]): number | null {
+    const totalEnvio = productos
+      .filter((producto) => this.esProductoEnvio(producto.nombre))
+      .reduce((acc, producto) => acc + Number(producto.subtotal ?? 0), 0);
+
+    return totalEnvio > 0 ? this.redondearPrecio(totalEnvio) : null;
+  }
+
   private calcularProductoPedido(
     producto: CreatePedidoDto['productos'][number],
     item: StkItem,
@@ -1202,6 +1226,7 @@ export class PedidoService {
     metodoPago: PedidoMetodoPago,
     peso?: number,
     cantidadParaDescuento?: number,
+    esProductoEnvio = false,
   ): PedidoProductoCalculado {
     const cantidad = this.obtenerCantidadProducto(producto);
     const precioBaseUnitario = this.obtenerPrecioMinoristaCotizado(item);
@@ -1211,8 +1236,9 @@ export class PedidoService {
     };
     const pesoProducto = peso ?? parseProductWeightFromDescription(item.descripcion);
     const aplicaDescuentoProducto =
-      metodoPago === 'transfer' ||
-      isEligibleForQuantityDiscount(productoDescuento, pesoProducto ?? 0);
+      !esProductoEnvio &&
+      (metodoPago === 'transfer' ||
+        isEligibleForQuantityDiscount(productoDescuento, pesoProducto ?? 0));
     const descuentoProductoPorcentaje = aplicaDescuentoProducto
       ? this.parsearPorcentajeDescuento(
           getDiscountPercentageForProduct(

--- a/src/whatsapp/whatsapp.service.spec.ts
+++ b/src/whatsapp/whatsapp.service.spec.ts
@@ -61,6 +61,29 @@ describe('WhatsappService', () => {
       expect(mensaje).toContain('ID: pedido-123');
     });
 
+    it('muestra el costo de envio desde el producto ENV cuando el campo esta en cero', () => {
+      const mensaje = service.formatearMensajeParaDelivery({
+        ...pedidoBase,
+        costo_envio: 0,
+        productos: [
+          {
+            nombre: 'Notebook Lenovo',
+            cantidad: 1,
+            precio_unitario: 1250000,
+            subtotal: 1250000,
+          },
+          {
+            nombre: 'ENV-07K-GM-DELIVERY',
+            cantidad: 1,
+            precio_unitario: 3999,
+            subtotal: 3999,
+          },
+        ],
+      });
+
+      expect(mensaje).toContain('$3999.00');
+    });
+
     it('no incluye la linea de Maps cuando no hay ubicacion real', () => {
       const mensaje = service.formatearMensajeParaDelivery({
         ...pedidoBase,

--- a/src/whatsapp/whatsapp.service.ts
+++ b/src/whatsapp/whatsapp.service.ts
@@ -40,7 +40,7 @@ export class WhatsappService {
       .join('\n');
 
     const ubicacion = pedido.cliente_ubicacion || 'No especificada';
-    const costoEnvio = (pedido.costo_envio != null) ? `$${Number(pedido.costo_envio).toFixed(2)}` : '$0.00';
+    const costoEnvio = this.formatearCostoEnvio(pedido, '$0.00');
     const tipoEnvio = pedido.delivery_method || 'pickup';
     const observaciones = pedido.observaciones_direccion ? `\n *Observaciones:* ${pedido.observaciones_direccion}` : '';
     const comprobante = this.formatearComprobante(pedido);
@@ -55,7 +55,7 @@ export class WhatsappService {
       .join('\n');
 
     const ubicacion = pedido.cliente_ubicacion || 'No especificada';
-    const costoEnvio = (pedido.costo_envio != null) ? `$${Number(pedido.costo_envio).toFixed(2)}` : '$0.00';
+    const costoEnvio = this.formatearCostoEnvio(pedido, '$0.00');
     const tipoEnvio = pedido.delivery_method || 'pickup';
     const observaciones = pedido.observaciones_direccion ? `\n *Observaciones:* ${pedido.observaciones_direccion}` : '';
     const callbackUrl = `https://shop.wetech.ar/checkout/callback?payment_id=${pedido.external_id}`;
@@ -73,7 +73,7 @@ export class WhatsappService {
       : '';
     const ubicacionLimpia = pedido.cliente_ubicacion?.trim();
     const ubicacion = ubicacionLimpia || 'Sin ubicación proporcionada';
-    const costoEnvio = (pedido.costo_envio != null) ? `$${Number(pedido.costo_envio).toFixed(2)}` : 'No especificado';
+    const costoEnvio = this.formatearCostoEnvio(pedido, 'No especificado');
     const observaciones = pedido.observaciones_direccion ? `\n *Observaciones:* ${pedido.observaciones_direccion}` : '';
     const comprobante = this.formatearComprobante(pedido);
     const mapsLink = this.formatearLinkMaps(ubicacionLimpia);
@@ -91,6 +91,34 @@ export class WhatsappService {
 
     const url = `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(ubicacionLimpia)}`;
     return `\n *Maps:* ${url}\n`;
+  }
+
+  private formatearCostoEnvio(pedido: any, fallback: string): string {
+    const costoDesdeProducto = this.obtenerCostoEnvioDesdeProductos(
+      pedido?.productos,
+    );
+    const costo = costoDesdeProducto ?? pedido?.costo_envio;
+
+    return costo != null ? `$${Number(costo).toFixed(2)}` : fallback;
+  }
+
+  private obtenerCostoEnvioDesdeProductos(productos: any): number | null {
+    if (!Array.isArray(productos)) {
+      return null;
+    }
+
+    const total = productos
+      .filter((producto) => this.esProductoEnvio(producto?.nombre))
+      .reduce(
+        (acc, producto) => acc + Number(producto?.subtotal ?? 0),
+        0,
+      );
+
+    return total > 0 ? total : null;
+  }
+
+  private esProductoEnvio(nombre?: string | null): boolean {
+    return /^ENV-\d+K-GM-DELIVERY$/i.test(String(nombre ?? ''));
   }
 
   private formatearComprobante(pedido: any): string {


### PR DESCRIPTION
… peso ni descuentos

- Identificar productos ENV mediante regex /^ENV-\d+K-GM-DELIVERY$/i
- Excluir estos productos del cálculo de peso total para envío gratis por peso
- No aplicar descuentos por cantidad ni por método de pago (transferencia) a productos ENV
- Calcular costo_envio desde productos ENV si existen, ignorando el campo costo_envio del DTO
- En whatsapp service, formatear el costo de envío usando el subtotal del producto ENV cuando esté presente
- Agregar tests: uso de ENV como costo de envío sin duplicar total, exclusión del peso para envío gratis, y formato en mensajes de delivery