### PR TITLE
feat(pedido): guardar direccion del cliente y ubicacion resuelta por …

### DIFF
--- a/migrations/20260728_add_cliente_direccion_to_pedido.sql
+++ b/migrations/20260728_add_cliente_direccion_to_pedido.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `pedido`
+  ADD COLUMN `cliente_direccion` varchar(512) NULL AFTER `cliente_ubicacion`;

--- a/src/pedido/entities/pedido.entity.ts
+++ b/src/pedido/entities/pedido.entity.ts
@@ -58,6 +58,9 @@ export class Pedido {
   @Column({ type: 'varchar', length: 512, nullable: true })
   cliente_ubicacion: string;
 
+  @Column({ type: 'varchar', length: 512, nullable: true })
+  cliente_direccion: string | null;
+
   @Column({ type: 'text', nullable: true })
   observaciones_direccion: string | null;
 

--- a/src/pedido/pedido.service.spec.ts
+++ b/src/pedido/pedido.service.spec.ts
@@ -545,7 +545,7 @@ describe('PedidoService recalculo de importes', () => {
     expect(stockService.reservarStock).not.toHaveBeenCalled();
   });
 
-  it('arma cliente_ubicacion priorizando la direccion resuelta por Maps', async () => {
+  it('guarda por separado la direccion del cliente y la resuelta por Maps', async () => {
     stkItemRepo.findOne.mockResolvedValue(itemConPrecio('ITEM-1', '10.01'));
 
     const dto = dtoBase({
@@ -578,6 +578,9 @@ describe('PedidoService recalculo de importes', () => {
 
     expect(pedido.cliente_ubicacion).toBe(
       'Direccion Real 456, M2000 Ciudad Real, Argentina',
+    );
+    expect(pedido.cliente_direccion).toBe(
+      'Billing Street 999, Billing City, Billing Region, BR, 9999',
     );
   });
 

--- a/src/pedido/pedido.service.ts
+++ b/src/pedido/pedido.service.ts
@@ -301,26 +301,26 @@ export class PedidoService {
     }
 
     const externalId = uuidv4().replace(/-/g, '');
-    const callePedido = dto.calle || dto.billing_address?.street || '';
-    const direccionPedido = {
-      calle: callePedido,
-      numero: dto.calle ? '' : dto.billing_address?.number || '',
-      ciudad: dto.ciudad || dto.billing_address?.city || '',
-      region: dto.region || dto.billing_address?.region || '',
-      pais: dto.pais || dto.billing_address?.country || '',
-      codigoPostal: dto.codigo_postal || dto.billing_address?.postal_code || '',
+    const direccionCliente = {
+      calle: dto.billing_address?.street || dto.calle || '',
+      numero: dto.billing_address?.number || '',
+      ciudad: dto.billing_address?.city || dto.ciudad || '',
+      region: dto.billing_address?.region || dto.region || '',
+      pais: dto.billing_address?.country || dto.pais || '',
+      codigoPostal: dto.billing_address?.postal_code || dto.codigo_postal || '',
     };
     const ubicacionDesdeDireccion = dto.direccion?.trim();
-    const ubicacionDesdePartes = [
-      `${direccionPedido.calle} ${direccionPedido.numero}`.trim(),
-      direccionPedido.ciudad,
-      direccionPedido.region,
-      direccionPedido.pais,
-      direccionPedido.codigoPostal,
+    const direccionClienteCompleta = [
+      `${direccionCliente.calle} ${direccionCliente.numero}`.trim(),
+      direccionCliente.ciudad,
+      direccionCliente.region,
+      direccionCliente.pais,
+      direccionCliente.codigoPostal,
     ]
       .filter(Boolean)
       .join(', ');
-    const clienteUbicacion = ubicacionDesdeDireccion || ubicacionDesdePartes;
+    const clienteUbicacion =
+      ubicacionDesdeDireccion || direccionClienteCompleta;
 
     const pedido = this.pedidoRepo.create({
       cliente_cuit: dto.cliente_cuit,
@@ -333,6 +333,7 @@ export class PedidoService {
       codigo_cupon: dto.codigo_cupon ?? undefined,
       delivery_method: dto.tipo_envio,
       cliente_ubicacion: clienteUbicacion,
+      cliente_direccion: direccionClienteCompleta || null,
       observaciones_direccion: dto.observaciones || undefined,
       telefono: dto.telefono || undefined,
       estado: 'PENDIENTE',

--- a/src/vta-comprobante/vta-comprobante.service.spec.ts
+++ b/src/vta-comprobante/vta-comprobante.service.spec.ts
@@ -28,6 +28,7 @@ describe('VtaComprobanteService crearDesdePedido', () => {
       cliente_mail: 'cliente@test.com',
       telefono: '1111111111',
       cliente_ubicacion: 'Calle 123, Ciudad, Provincia, AR, 1000',
+      cliente_direccion: null,
       observaciones_direccion: '',
       productos,
       total,
@@ -345,6 +346,35 @@ describe('VtaComprobanteService crearDesdePedido', () => {
         direccion: 'Joaquin V. Gonzalez 450',
         provincia: 'Mendoza',
         cpa: 'M5519',
+      }),
+    );
+  });
+
+  it('crea o actualiza vta_cliente con la direccion declarada por el cliente', async () => {
+    await service.crearDesdePedido({
+      ...pedidoBase(
+        [
+          {
+            nombre: 'ITEM-SIN-AJUSTE',
+            cantidad: 1,
+            precio_unitario: 100,
+            subtotal: 100,
+            ajuste_porcentaje: null,
+          },
+        ],
+        100,
+      ),
+      cliente_ubicacion: 'Dorrego 229, M5539 Las Heras, Mendoza, Argentina',
+      cliente_direccion:
+        'B° Unidad Latinoamérica MC C3, Las Heras, Mendoza, AR, 5539',
+    } as Pedido);
+
+    expect(clienteService.findOrCreateOrUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        direccion: 'B° Unidad Latinoamérica MC C3',
+        localidad: 'Las Heras',
+        provincia: 'Mendoza',
+        cpa: '5539',
       }),
     );
   });

--- a/src/vta-comprobante/vta-comprobante.service.ts
+++ b/src/vta-comprobante/vta-comprobante.service.ts
@@ -174,7 +174,9 @@ export class VtaComprobanteService {
     if (!pedido) throw new NotFoundException('Pedido no encontrado');
 
     // 👤 Asegurar que el cliente exista (crear/actualizar según corresponda)
-    const ubicacionParsed = this.parseUbicacion(pedido.cliente_ubicacion);
+    const ubicacionParsed = this.parseUbicacion(
+      pedido.cliente_direccion || pedido.cliente_ubicacion,
+    );
 
     // 🧾 Consumidor final tiene CUIL; el CUIT es de quien factura A (RI/monotributo).
     const tipoDocumento = pedido.factura_tipo === 'A' ? 'CUIT' : 'CUIL';

--- a/src/whatsapp/whatsapp.service.spec.ts
+++ b/src/whatsapp/whatsapp.service.spec.ts
@@ -7,6 +7,7 @@ describe('WhatsappService', () => {
     cliente_nombre: 'Juan Perez',
     telefono: '+5491123456789',
     cliente_ubicacion: 'Av. Siempre Viva 742, Springfield, Buenos Aires, Argentina, 1000',
+    cliente_direccion: 'Barrio Los Alamos M3 C2, Springfield, Buenos Aires, AR, 1000',
     costo_envio: 1500,
     observaciones_direccion: 'Tocar timbre 2B',
     comprobante_tipo: 'FA',
@@ -51,7 +52,13 @@ describe('WhatsappService', () => {
 
       expect(mensaje).toContain('*Cliente:* Juan Perez');
       expect(mensaje).toContain('*Telefono:* +5491123456789');
-      expect(mensaje).toContain(`*Ubicación:* ${pedidoBase.cliente_ubicacion}`);
+      expect(mensaje).toContain(
+        `*Dirección cliente:* ${pedidoBase.cliente_direccion}`,
+      );
+      expect(mensaje).not.toContain('*Ubicación:*');
+      expect(mensaje).not.toContain(
+        `\n *Ubicación:* ${pedidoBase.cliente_ubicacion}`,
+      );
       expect(mensaje).toContain(`*Maps:* ${linkEsperado}`);
       expect(mensaje).toContain('*Costo envío:* $1500.00');
       expect(mensaje).toContain('*Productos:*');
@@ -90,7 +97,8 @@ describe('WhatsappService', () => {
         cliente_ubicacion: '   ',
       });
 
-      expect(mensaje).toContain('*Ubicación:* Sin ubicación proporcionada');
+      expect(mensaje).not.toContain('*Ubicación:*');
+      expect(mensaje).not.toContain('Sin ubicación proporcionada');
       expect(mensaje).not.toContain('*Maps:*');
       expect(mensaje).not.toContain('google.com/maps');
     });

--- a/src/whatsapp/whatsapp.service.ts
+++ b/src/whatsapp/whatsapp.service.ts
@@ -72,14 +72,17 @@ export class WhatsappService {
           .join('\n')}`
       : '';
     const ubicacionLimpia = pedido.cliente_ubicacion?.trim();
-    const ubicacion = ubicacionLimpia || 'Sin ubicación proporcionada';
+    const direccionClienteLimpia = pedido.cliente_direccion?.trim();
+    const direccionCliente = direccionClienteLimpia
+      ? `\n *Dirección:* ${direccionClienteLimpia}`
+      : '';
     const costoEnvio = this.formatearCostoEnvio(pedido, 'No especificado');
     const observaciones = pedido.observaciones_direccion ? `\n *Observaciones:* ${pedido.observaciones_direccion}` : '';
     const comprobante = this.formatearComprobante(pedido);
     const mapsLink = this.formatearLinkMaps(ubicacionLimpia);
     const telefono = pedido.telefono || 'No informado';
 
-    return `*Pedido para Delivery ${comprobante}*\n\n *Cliente:* ${pedido.cliente_nombre}\n *Telefono:* ${telefono}\n *Ubicación:* ${ubicacion}${observaciones}${mapsLink}\n *Costo envío:* ${costoEnvio}${productos}\n\nID: ${pedido.external_id}`;
+    return `*Pedido para Delivery ${comprobante}*\n\n *Cliente:* ${pedido.cliente_nombre}\n *Telefono:* ${telefono}${direccionCliente}${observaciones}${mapsLink}\n *Costo envío:* ${costoEnvio}${productos}\n\nID: ${pedido.external_id}`;
   }
 
   private formatearLinkMaps(ubicacion?: string | null): string {


### PR DESCRIPTION
…separado

- Agregar campo cliente_direccion en Pedido entity (dirección declarada por el cliente)
- cliente_ubicacion queda como la dirección resuelta por Maps/direccion ingresada
- En PedidoService: construir direccionClienteCompleta desde billing_address o campos del DTO
- Priorizar dto.direccion para cliente_ubicacion (fallback a direccionClienteCompleta)
- En VtaComprobanteService: usar cliente_direccion para crear/actualizar vta_cliente (fallback a cliente_ubicacion)
- En WhatsApp: mostrar 'Dirección:' en lugar de 'Ubicación:' para mensajes de delivery
- Tests: verificar que cliente_direccion y cliente_ubicacion se guarden por separado