### PR TITLE
feat(pedido): contar producto ENV para peso y bonificarlo al 100% si …

### DIFF
--- a/src/pedido/pedido.service.spec.ts
+++ b/src/pedido/pedido.service.spec.ts
@@ -1343,7 +1343,7 @@ describe('PedidoService recalculo de importes', () => {
     expect(stockService.reservarStock).not.toHaveBeenCalled();
   });
 
-  it('no cuenta el producto ENV para envio gratis por peso', async () => {
+  it('cuenta el producto ENV para envio gratis por peso y lo bonifica al 100%', async () => {
     stkItemRepo.findOne
       .mockResolvedValueOnce(
         itemConPrecio(
@@ -1369,7 +1369,7 @@ describe('PedidoService recalculo de importes', () => {
     const dto = dtoBase({
       tipo_envio: 'shipping',
       costo_envio: 3999,
-      total: 4899,
+      total: 900,
       productos: [
         {
           nombre: 'ITEM-9KG',
@@ -1380,16 +1380,20 @@ describe('PedidoService recalculo de importes', () => {
         {
           nombre: 'ENV-07K-GM-DELIVERY',
           cantidad: 1,
-          precio_unitario: 3999,
-          subtotal: 3999,
+          precio_unitario: 0,
+          subtotal: 0,
+          ajuste_porcentaje: 100,
         },
       ],
     });
 
     const { pedido } = await service.crear(dto);
 
-    expect(pedido.costo_envio).toBe(3999);
-    expect(pedido.total).toBe(4899);
+    expect(pedido.costo_envio).toBe(0);
+    expect(pedido.total).toBe(900);
+    expect(pedido.productos[1].precio_unitario).toBe(0);
+    expect(pedido.productos[1].subtotal).toBe(0);
+    expect(pedido.productos[1].ajuste_porcentaje).toBe(100);
   });
 
   it('no aplica envio gratis por peso para pickup', async () => {

--- a/src/pedido/pedido.service.ts
+++ b/src/pedido/pedido.service.ts
@@ -171,12 +171,8 @@ export class PedidoService {
       const cantidad = this.obtenerCantidadProducto(producto);
       const esProductoEnvio = this.esProductoEnvio(producto.nombre);
       const categoriaProducto = this.derivarCategoriaProducto(item.grupo);
-      const peso = esProductoEnvio
-        ? undefined
-        : parseProductWeightFromDescription(item.descripcion);
-      if (!esProductoEnvio) {
-        pesoTotalKg += (peso ?? 0) * cantidad;
-      }
+      const peso = parseProductWeightFromDescription(item.descripcion);
+      pesoTotalKg += (peso ?? 0) * cantidad;
       // Identidad (Marca+Material) desde atributos: base confiable para el
       // descuento por cantidad, en vez de parsear prefijos del id.
       const identidad: FilamentIdentity = esProductoEnvio
@@ -214,6 +210,10 @@ export class PedidoService {
       );
     }
 
+    const aplicaEnvioGratisPorPeso =
+      dto.tipo_envio === 'shipping' &&
+      pesoTotalKg >= FREE_SHIPPING_MIN_WEIGHT_KG;
+
     for (const {
       producto,
       item,
@@ -241,6 +241,7 @@ export class PedidoService {
         esProductoEnvio,
         requiereFactura,
         identidad,
+        aplicaEnvioGratisPorPeso,
       );
       const diferenciaProducto = this.obtenerDiferenciaProducto(
         producto,
@@ -1339,6 +1340,7 @@ export class PedidoService {
     esProductoEnvio = false,
     incluyeIvaFactura = false,
     identidad: FilamentIdentity = { category: item.grupo },
+    aplicaEnvioGratisPorPeso = false,
   ): PedidoProductoCalculado {
     const cantidad = this.obtenerCantidadProducto(producto);
     const precioBaseUnitario = this.obtenerPrecioListaCotizado(
@@ -1360,10 +1362,10 @@ export class PedidoService {
           ),
         )
       : 0;
-    const descuentoPorcentaje = Math.max(
-      descuentoProductoPorcentaje,
-      porcentajeCuponAplicable,
-    );
+    const descuentoPorcentaje =
+      esProductoEnvio && aplicaEnvioGratisPorPeso
+        ? 100
+        : Math.max(descuentoProductoPorcentaje, porcentajeCuponAplicable);
     if (incluyeIvaFactura) {
       const subtotalBrutoCalculado = this.redondear2(
         precioBaseUnitario *


### PR DESCRIPTION
…alcanza envío gratis

- Incluir productos de envío (ENV-*) en el cálculo de pesoTotalKg para determinar envío gratis por peso
- Si se alcanza el mínimo de 10kg, aplicar descuento del 100% al producto ENV (costo_envio = 0)
- Actualizar test: renombrar y ajustar expectativas (total sin costo de envío, producto ENV con ajuste 100%)