### PR TITLE
fix(pedido): excluir productos ENV del peso para envío gratis y docum…

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,11 +86,25 @@ No es necesario enviar `external_id`; se genera internamente.
 
 Los descuentos automáticos de productos, incluyendo el descuento base de filamentos y los descuentos diferenciales por cantidad o marca elegible, se aplican solo cuando `metodo_pago` es `transfer`. Para pagos `online`, el backend no aplica descuentos automáticos de producto; solo considera cupones válidos para la modalidad correspondiente.
 
+Si se envia `factura_tipo` con valor `A` o `B`, el backend valida los importes de cada producto con IVA incluido y guarda internamente el neto mas el IVA discriminado. Actualmente la alicuota aplicada es 21% por linea. Cuando se incorporen impresoras a la venta web, no se debe reutilizar ese porcentaje: las impresoras deben calcularse con IVA 10.5%, resolviendo la alicuota por producto.
+
+#### Envio gratis por peso y productos `ENV`
+
+El envio gratis aplica solo para pedidos `tipo_envio: "shipping"` cuando el peso total de productos reales es mayor o igual a 10 kg. Los productos de envio con formato `ENV-<n>K-GM-DELIVERY` no suman peso: la `K` del codigo representa kilometros de delivery, no kilos.
+
+Si los productos reales llegan al umbral de envio gratis, el producto `ENV` debe seguir dentro de `productos`, pero bonificado al 100%:
+
 ```json
 {
-`subtotal` en cada producto es obligatorio y representa el importe bruto de la línea (sin descuento), mientras que `precio_unitario` representa el valor neto por unidad (con descuento aplicado).
+  "nombre": "ENV-11K-GM-DELIVERY",
+  "cantidad": 1,
+  "precio_unitario": 0,
+  "subtotal": 0,
+  "ajuste_porcentaje": 100
+}
+```
 
-Si se envia `factura_tipo` con valor `A` o `B`, el backend valida los importes de cada producto con IVA incluido y guarda internamente el neto mas el IVA discriminado. Actualmente la alicuota aplicada es 21% por linea. Cuando se incorporen impresoras a la venta web, no se debe reutilizar ese porcentaje: las impresoras deben calcularse con IVA 10.5%, resolviendo la alicuota por producto.
+En ese caso `costo_envio` debe enviarse como `0` y el `total` no debe incluir el envio. Si los productos reales pesan menos de 10 kg, el `ENV` mantiene su precio normal aunque el codigo indique, por ejemplo, `11K`.
 
 ```json
 {

--- a/src/pedido/pedido.service.spec.ts
+++ b/src/pedido/pedido.service.spec.ts
@@ -1343,11 +1343,11 @@ describe('PedidoService recalculo de importes', () => {
     expect(stockService.reservarStock).not.toHaveBeenCalled();
   });
 
-  it('cuenta el producto ENV para envio gratis por peso y lo bonifica al 100%', async () => {
+  it('bonifica el producto ENV al 100% cuando los productos llegan al peso de envio gratis', async () => {
     stkItemRepo.findOne
       .mockResolvedValueOnce(
         itemConPrecio(
-          'ITEM-9KG',
+          'ITEM-10KG',
           '100',
           'PES',
           '1',
@@ -1369,13 +1369,13 @@ describe('PedidoService recalculo de importes', () => {
     const dto = dtoBase({
       tipo_envio: 'shipping',
       costo_envio: 3999,
-      total: 900,
+      total: 1000,
       productos: [
         {
-          nombre: 'ITEM-9KG',
-          cantidad: 9,
+          nombre: 'ITEM-10KG',
+          cantidad: 10,
           precio_unitario: 100,
-          subtotal: 900,
+          subtotal: 1000,
         },
         {
           nombre: 'ENV-07K-GM-DELIVERY',
@@ -1390,10 +1390,63 @@ describe('PedidoService recalculo de importes', () => {
     const { pedido } = await service.crear(dto);
 
     expect(pedido.costo_envio).toBe(0);
-    expect(pedido.total).toBe(900);
+    expect(pedido.total).toBe(1000);
     expect(pedido.productos[1].precio_unitario).toBe(0);
     expect(pedido.productos[1].subtotal).toBe(0);
     expect(pedido.productos[1].ajuste_porcentaje).toBe(100);
+  });
+
+  it('no usa los kilometros del producto ENV como peso para envio gratis', async () => {
+    stkItemRepo.findOne
+      .mockResolvedValueOnce(
+        itemConPrecio(
+          'ITEM-1KG',
+          '19999',
+          'PES',
+          '1',
+          null,
+          'Producto 1kg',
+        ),
+      )
+      .mockResolvedValueOnce(
+        itemConPrecio(
+          'ENV-11K-GM-DELIVERY',
+          '5599',
+          'PES',
+          '1',
+          null,
+          'Envio 11km delivery',
+        ),
+      );
+
+    const dto = dtoBase({
+      tipo_envio: 'shipping',
+      costo_envio: 5599,
+      total: 25598,
+      productos: [
+        {
+          nombre: 'ITEM-1KG',
+          cantidad: 1,
+          precio_unitario: 19999,
+          subtotal: 19999,
+        },
+        {
+          nombre: 'ENV-11K-GM-DELIVERY',
+          cantidad: 1,
+          precio_unitario: 5599,
+          subtotal: 5599,
+          ajuste_porcentaje: 0,
+        },
+      ],
+    });
+
+    const { pedido } = await service.crear(dto);
+
+    expect(pedido.costo_envio).toBe(5599);
+    expect(pedido.total).toBe(25598);
+    expect(pedido.productos[1].precio_unitario).toBe(5599);
+    expect(pedido.productos[1].subtotal).toBe(5599);
+    expect(pedido.productos[1].ajuste_porcentaje).toBeNull();
   });
 
   it('no aplica envio gratis por peso para pickup', async () => {

--- a/src/pedido/pedido.service.ts
+++ b/src/pedido/pedido.service.ts
@@ -171,8 +171,14 @@ export class PedidoService {
       const cantidad = this.obtenerCantidadProducto(producto);
       const esProductoEnvio = this.esProductoEnvio(producto.nombre);
       const categoriaProducto = this.derivarCategoriaProducto(item.grupo);
-      const peso = parseProductWeightFromDescription(item.descripcion);
-      pesoTotalKg += (peso ?? 0) * cantidad;
+      // En ENV-<n>K-GM-DELIVERY, la K representa kilometros de delivery,
+      // no kilos. Estos productos no participan del peso para envio gratis.
+      const peso = esProductoEnvio
+        ? undefined
+        : parseProductWeightFromDescription(item.descripcion);
+      if (!esProductoEnvio) {
+        pesoTotalKg += (peso ?? 0) * cantidad;
+      }
       // Identidad (Marca+Material) desde atributos: base confiable para el
       // descuento por cantidad, en vez de parsear prefijos del id.
       const identidad: FilamentIdentity = esProductoEnvio


### PR DESCRIPTION
…entar regla

- Volver a excluir productos ENV-* del cálculo de pesoTotalKg (la 'K' en el código representa kilómetros de delivery, no kilos)
- Si los productos reales alcanzan ≥ 10 kg, bonificar ENV al 100% (ajuste_porcentaje: 100, precio_unitario: 0, subtotal: 0)
- Si no alcanzan, ENV mantiene su precio normal (ajuste_porcentaje: null)
- Agregar test que verifica que el código 'ENV-11K-GM-DELIVERY' no suma 11 kg al peso total
- Renombrar test anterior para claridad
- Documentar en README la regla de envío gratis por peso y el manejo de productos ENV