### PR TITLE
fix(vta-comprobante): respetar subtotal de línea para evitar diferenc…

### DIFF
--- a/src/vta-comprobante/vta-comprobante.service.spec.ts
+++ b/src/vta-comprobante/vta-comprobante.service.spec.ts
@@ -105,6 +105,59 @@ describe('VtaComprobanteService crearDesdePedido', () => {
     );
   });
 
+  it('respeta el subtotal de linea cuando el precio unitario redondeado no multiplica exacto', async () => {
+    await service.crearDesdePedido(
+      pedidoBase(
+        [
+          {
+            nombre: 'HB-PLA-1KG-NEGR',
+            cantidad: 3,
+            precio_unitario: 17882,
+            subtotal: 53645,
+            ajuste_porcentaje: 20,
+          },
+          {
+            nombre: 'HB-PLA-1KG-BLAN',
+            cantidad: 2,
+            precio_unitario: 17882,
+            subtotal: 35763,
+            ajuste_porcentaje: 20,
+          },
+        ],
+        89408,
+      ),
+    );
+
+    expect(comprobanteRepository.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        total: 89408,
+        subtotal: 89408,
+      }),
+    );
+    expect(comprobanteItemService.create).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        itemId: 'HB-PLA-1KG-NEGR',
+        cantidad: 3,
+        precio: 22352.08,
+        importe: 53645,
+        ajuste: -20,
+        ajuste_neto: -13411.25,
+      }),
+    );
+    expect(comprobanteItemService.create).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        itemId: 'HB-PLA-1KG-BLAN',
+        cantidad: 2,
+        precio: 22351.88,
+        importe: 35763,
+        ajuste: -20,
+        ajuste_neto: -8940.75,
+      }),
+    );
+  });
+
   it('no registra ajuste cuando el producto no tiene ajuste_porcentaje', async () => {
     await service.crearDesdePedido(
       pedidoBase(

--- a/src/vta-comprobante/vta-comprobante.service.ts
+++ b/src/vta-comprobante/vta-comprobante.service.ts
@@ -215,7 +215,10 @@ export class VtaComprobanteService {
     const itemsCalculo = (pedido.productos ?? []).map((producto) => {
       const cantidad = Number(producto.cantidad ?? 0);
       const precioFinalUnitario = Number(producto.precio_unitario ?? 0);
-      const importeFinal = this.redondear2(cantidad * precioFinalUnitario);
+      const subtotalProducto = Number(producto.subtotal);
+      const importeFinal = Number.isFinite(subtotalProducto)
+        ? this.redondear2(subtotalProducto)
+        : this.redondear2(cantidad * precioFinalUnitario);
       const ajustePorcentaje = Number(producto.ajuste_porcentaje ?? 0);
       const tieneAjustePorcentaje =
         Number.isFinite(ajustePorcentaje) &&


### PR DESCRIPTION
…ias por redondeo

- En itemsCalculo, usar producto.subtotal como importeFinal cuando es válido (en lugar de recalcular con precio_unitario * cantidad)
- Esto evita discrepancias de centavos cuando el precio unitario redondeado no multiplica exactamente al subtotal
- Agregar test que verifica el comportamiento con productos cuyos subtotales no coinciden con precio_unitario * cantidad