### PR TITLE
fix(transfer): validar que el comprobante cobrado pertenezca al pedid…

### DIFF
--- a/src/pedido/pedido-comprobante-reference.ts
+++ b/src/pedido/pedido-comprobante-reference.ts
@@ -1,0 +1,5 @@
+export const PEDIDO_COMPROBANTE_REFERENCE_PREFIX = 'PEDIDO_WEB:';
+
+export function buildPedidoComprobanteReference(externalId: string): string {
+  return `${PEDIDO_COMPROBANTE_REFERENCE_PREFIX}${externalId}`;
+}

--- a/src/pedido/pedido-expiration.service.spec.ts
+++ b/src/pedido/pedido-expiration.service.spec.ts
@@ -15,19 +15,25 @@ describe('PedidoExpirationService', () => {
     }
   });
 
-  function createService() {
+  function createService(pedidos: any[] = []) {
     const pedidoRepo = {
-      find: jest.fn().mockResolvedValue([]),
+      find: jest.fn().mockResolvedValue(pedidos),
+    };
+    const cobrosService = {
+      tieneCobroFacturaDelPedido: jest.fn().mockResolvedValue(false),
+    };
+    const pedidoService = {
+      aprobarTransferencia: jest.fn(),
     };
 
     const service = new PedidoExpirationService(
       pedidoRepo as any,
       {} as any,
-      {} as any,
-      {} as any,
+      cobrosService as any,
+      pedidoService as any,
     );
 
-    return { service, pedidoRepo };
+    return { service, pedidoRepo, cobrosService, pedidoService };
   }
 
   it.each(['false', '0', 'no', 'off', ' FALSE '])(
@@ -49,5 +55,24 @@ describe('PedidoExpirationService', () => {
     await service.scheduledTransferApproval();
 
     expect(pedidoRepo.find).toHaveBeenCalledTimes(1);
+  });
+
+  it('no aprueba cuando el comprobante cobrado no pertenece al pedido', async () => {
+    delete process.env.PEDIDO_TRANSFER_APPROVAL_ENABLED;
+    const pedido = {
+      external_id: 'pedido-eliminado',
+      comprobante_tipo: 'FX',
+      comprobante_numero: 'X 00001 00000001',
+    };
+    const { service, cobrosService, pedidoService } = createService([pedido]);
+
+    await service.scheduledTransferApproval();
+
+    expect(cobrosService.tieneCobroFacturaDelPedido).toHaveBeenCalledWith(
+      'FX',
+      'X 00001 00000001',
+      pedido,
+    );
+    expect(pedidoService.aprobarTransferencia).not.toHaveBeenCalled();
   });
 });

--- a/src/pedido/pedido-expiration.service.ts
+++ b/src/pedido/pedido-expiration.service.ts
@@ -53,7 +53,8 @@ export class PedidoExpirationService {
     let fallos = 0;
 
     for (const pedido of pendientes) {
-      const liberacionesExitosas: Array<{ nombre: string; cantidad: number }> = [];
+      const liberacionesExitosas: Array<{ nombre: string; cantidad: number }> =
+        [];
       let tieneErrores = false;
 
       try {
@@ -61,7 +62,10 @@ export class PedidoExpirationService {
         for (const p of pedido.productos) {
           try {
             await this.existenciaService.liberarStock(p.nombre, p.cantidad);
-            liberacionesExitosas.push({ nombre: p.nombre, cantidad: p.cantidad });
+            liberacionesExitosas.push({
+              nombre: p.nombre,
+              cantidad: p.cantidad,
+            });
           } catch (stockError) {
             tieneErrores = true;
             this.logger.warn(
@@ -139,11 +143,17 @@ export class PedidoExpirationService {
       if (!tipo || !comprobante) continue;
 
       try {
-        const tieneCobro = await this.cobrosService.tieneCobroFactura(tipo, comprobante);
+        const tieneCobro = await this.cobrosService.tieneCobroFacturaDelPedido(
+          tipo,
+          comprobante,
+          pedido,
+        );
         if (!tieneCobro) continue;
 
         await this.pedidoService.aprobarTransferencia(pedido.external_id);
-        this.logger.log(`[${pedido.external_id}] Pedido transferencia aprobado por cobro registrado`);
+        this.logger.log(
+          `[${pedido.external_id}] Pedido transferencia aprobado por cobro registrado`,
+        );
       } catch (e) {
         this.logger.error(
           `[${pedido.external_id}] Error en aprobación automática: ${e?.message || e}`,
@@ -153,9 +163,8 @@ export class PedidoExpirationService {
   }
 
   private isTransferApprovalEnabled(): boolean {
-    const value = process.env.PEDIDO_TRANSFER_APPROVAL_ENABLED
-      ?.trim()
-      .toLowerCase();
+    const value =
+      process.env.PEDIDO_TRANSFER_APPROVAL_ENABLED?.trim().toLowerCase();
 
     return !['false', '0', 'no', 'off'].includes(value ?? '');
   }

--- a/src/vta-comprobante/cobros.service.spec.ts
+++ b/src/vta-comprobante/cobros.service.spec.ts
@@ -1,0 +1,89 @@
+import { CobrosService } from './cobros.service';
+
+describe('CobrosService tieneCobroFacturaDelPedido', () => {
+  const creado = new Date('2026-08-04T12:00:00Z');
+  const pedido = {
+    external_id: 'pedido-original',
+    cliente_cuit: '20123456789',
+    cliente_mail: 'cliente@test.com',
+    total: 1500,
+    creado,
+  };
+  const comprobanteRepo = {
+    findOne: jest.fn(),
+  };
+  const cobroFacturaRepo = {
+    findOne: jest.fn(),
+  };
+  let service: CobrosService;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    service = new CobrosService(
+      {} as any,
+      comprobanteRepo as any,
+      {} as any,
+      {} as any,
+      cobroFacturaRepo as any,
+    );
+    cobroFacturaRepo.findOne.mockResolvedValue({ cobro: 'COBRO-1' });
+  });
+
+  it('acepta un comprobante nuevo vinculado al mismo pedido', async () => {
+    comprobanteRepo.findOne.mockResolvedValue({
+      cliente: pedido.cliente_cuit,
+      total: pedido.total,
+      anulado: false,
+      observaciones_int: 'PEDIDO_WEB:pedido-original',
+    });
+
+    await expect(
+      service.tieneCobroFacturaDelPedido('FX', 'X 00001 00000001', pedido),
+    ).resolves.toBe(true);
+  });
+
+  it('rechaza un numero reutilizado vinculado a otro pedido', async () => {
+    comprobanteRepo.findOne.mockResolvedValue({
+      cliente: pedido.cliente_cuit,
+      total: pedido.total,
+      anulado: false,
+      observaciones_int: 'PEDIDO_WEB:otro-pedido',
+    });
+
+    await expect(
+      service.tieneCobroFacturaDelPedido('FX', 'X 00001 00000001', pedido),
+    ).resolves.toBe(false);
+    expect(cobroFacturaRepo.findOne).not.toHaveBeenCalled();
+  });
+
+  it('acepta un comprobante anterior que coincide con los datos del pedido', async () => {
+    comprobanteRepo.findOne.mockResolvedValue({
+      cliente: pedido.cliente_cuit,
+      email: pedido.cliente_mail,
+      total: pedido.total,
+      fecha: new Date(creado.getTime() + 5_000),
+      anulado: false,
+      observaciones_int: null,
+    });
+
+    await expect(
+      service.tieneCobroFacturaDelPedido('FX', 'X 00001 00000001', pedido),
+    ).resolves.toBe(true);
+  });
+
+  it('rechaza un comprobante anterior reutilizado mucho despues', async () => {
+    comprobanteRepo.findOne.mockResolvedValue({
+      cliente: pedido.cliente_cuit,
+      email: pedido.cliente_mail,
+      total: pedido.total,
+      fecha: new Date(creado.getTime() + 24 * 60 * 60_000),
+      anulado: false,
+      observaciones_int: null,
+    });
+
+    await expect(
+      service.tieneCobroFacturaDelPedido('FX', 'X 00001 00000001', pedido),
+    ).resolves.toBe(false);
+    expect(cobroFacturaRepo.findOne).not.toHaveBeenCalled();
+  });
+});

--- a/src/vta-comprobante/cobros.service.ts
+++ b/src/vta-comprobante/cobros.service.ts
@@ -1,4 +1,4 @@
-import { BadRequestException, Injectable, NotFoundException } from "@nestjs/common";
+import { BadRequestException, Injectable, Logger, NotFoundException } from "@nestjs/common";
 import { InjectRepository } from "@nestjs/typeorm";
 import { DataSource, Repository } from "typeorm";
 
@@ -7,11 +7,18 @@ import { VtaCobro } from "../vta-cobro/entities/vta-cobro.entity";
 import { VtaCobroMedio } from "../vta-cobro-medio/entities/vta-cobro-medio.entity";
 import { VtaCobroFactura } from "../vta-cobro-factura/entities/vta-cobro-factura.entity";
 import { CobrarFacturaDto } from "./dto/cobrar-factura.dto";
+import { Pedido } from "../pedido/entities/pedido.entity";
+import {
+  buildPedidoComprobanteReference,
+  PEDIDO_COMPROBANTE_REFERENCE_PREFIX,
+} from "../pedido/pedido-comprobante-reference";
 
 type Modalidad = CobrarFacturaDto["modalidad"];
 
 @Injectable()
 export class CobrosService {
+  private readonly logger = new Logger(CobrosService.name);
+
   constructor(
     private readonly dataSource: DataSource,
 
@@ -169,6 +176,77 @@ export class CobrosService {
       where: { tipo, factura: comprobante },
     });
     return !!cobro;
+  }
+
+  async tieneCobroFacturaDelPedido(
+    tipo: string,
+    comprobante: string,
+    pedido: Pick<
+      Pedido,
+      "external_id" | "cliente_cuit" | "cliente_mail" | "total" | "creado"
+    >,
+  ): Promise<boolean> {
+    const factura = await this.comprobanteRepo.findOne({
+      where: { tipo, comprobante },
+    });
+
+    if (!factura || factura.anulado) {
+      return false;
+    }
+
+    if (!this.comprobantePerteneceAlPedido(factura, pedido)) {
+      this.logger.warn(
+        `[${pedido.external_id}] Se ignora cobro de ${tipo} ${comprobante}: el comprobante no corresponde al pedido`,
+      );
+      return false;
+    }
+
+    return this.tieneCobroFactura(tipo, comprobante);
+  }
+
+  private comprobantePerteneceAlPedido(
+    factura: VtaComprobante,
+    pedido: Pick<
+      Pedido,
+      "external_id" | "cliente_cuit" | "cliente_mail" | "total" | "creado"
+    >,
+  ): boolean {
+    const referencia = factura.observaciones_int?.trim();
+    const referenciaEsperada = buildPedidoComprobanteReference(
+      pedido.external_id,
+    );
+    const clienteFactura = (factura.cliente || factura.numero_documento || "")
+      .trim()
+      .toLowerCase();
+    const clientePedido = pedido.cliente_cuit.trim().toLowerCase();
+    const totalFactura = Number(factura.total);
+    const totalPedido = Number(pedido.total);
+    const datosPrincipalesCoinciden =
+      clienteFactura === clientePedido &&
+      Number.isFinite(totalFactura) &&
+      Number.isFinite(totalPedido) &&
+      Math.abs(totalFactura - totalPedido) < 0.01;
+
+    if (referencia?.startsWith(PEDIDO_COMPROBANTE_REFERENCE_PREFIX)) {
+      return referencia === referenciaEsperada && datosPrincipalesCoinciden;
+    }
+
+    // Compatibilidad para comprobantes creados antes de incorporar la referencia.
+    // Además de cliente y total, deben haberse creado cerca del pedido original;
+    // así un número eliminado y reutilizado no puede aprobar un pedido antiguo.
+    const fechaFactura = factura.fecha?.getTime();
+    const fechaPedido = pedido.creado?.getTime();
+    const fechasCoinciden =
+      Number.isFinite(fechaFactura) &&
+      Number.isFinite(fechaPedido) &&
+      Math.abs((fechaFactura as number) - (fechaPedido as number)) <=
+        60 * 60_000;
+    const emailFactura = factura.email?.trim().toLowerCase();
+    const emailPedido = pedido.cliente_mail?.trim().toLowerCase();
+    const emailsCoinciden =
+      !emailFactura || !emailPedido || emailFactura === emailPedido;
+
+    return datosPrincipalesCoinciden && fechasCoinciden && emailsCoinciden;
   }
 
   private buildBuckets(modalidad: Modalidad, total: number) {

--- a/src/vta-comprobante/vta-comprobante.service.spec.ts
+++ b/src/vta-comprobante/vta-comprobante.service.spec.ts
@@ -36,6 +36,8 @@ describe('VtaComprobanteService crearDesdePedido', () => {
 
   const pedidoBase = (productos: any[], total: number): Pedido =>
     ({
+      external_id: 'pedido-test-123',
+      creado: new Date('2026-08-04T12:00:00Z'),
       cliente_cuit: '20123456789',
       cliente_nombre: 'Cliente Test',
       cliente_mail: 'cliente@test.com',
@@ -63,6 +65,28 @@ describe('VtaComprobanteService crearDesdePedido', () => {
         const puntoDeVenta = letra === 'X' ? '00001' : '00005';
         return `${letra} ${puntoDeVenta} 00000001`;
       });
+  });
+
+  it('vincula internamente el comprobante con el pedido', async () => {
+    await service.crearDesdePedido(
+      pedidoBase(
+        [
+          {
+            nombre: 'ITEM-REFERENCIA',
+            cantidad: 1,
+            precio_unitario: 100,
+            subtotal: 100,
+          },
+        ],
+        100,
+      ),
+    );
+
+    expect(comprobanteRepository.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        observaciones_int: 'PEDIDO_WEB:pedido-test-123',
+      }),
+    );
   });
 
   it('registra ajuste de descuento usando ajuste_porcentaje del pedido', async () => {

--- a/src/vta-comprobante/vta-comprobante.service.ts
+++ b/src/vta-comprobante/vta-comprobante.service.ts
@@ -4,6 +4,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { DataSource, DeepPartial, Repository } from 'typeorm';
 import { VtaComprobante } from './entities/vta-comprobante.entity';
 import { Pedido } from 'src/pedido/entities/pedido.entity';
+import { buildPedidoComprobanteReference } from 'src/pedido/pedido-comprobante-reference';
 import { VtaComprobanteItemService } from 'src/vta-comprobante-item/vta-comprobante-item.service';
 import { VtaClienteService } from 'src/vta_cliente/vta_cliente.service';
 import { CreateVtaClienteDto } from 'src/vta_cliente/dto/create-vta_cliente.dto';
@@ -317,6 +318,7 @@ export class VtaComprobanteService {
       entregado: 0,
       entregado$: 0,
       trabajador: 'WEB',
+      observaciones_int: buildPedidoComprobanteReference(pedido.external_id),
       ...cobroFields,
       adjuntos: false,
       adjuntado: false,


### PR DESCRIPTION
…o antes de aprobar

- Agregar método tieneCobroFacturaDelPedido en CobrosService
- Verificar que el cobro corresponda al pedido por: referencia PEDIDO_WEB, cliente, total, fecha y email
- En comprobante, guardar observaciones_int con referencia al pedido (PEDIDO_WEB:external_id)
- Ignorar cobros de comprobantes que no pertenecen al pedido (evita aprobaciones erróneas)
- Agregar tests: rechaza aprobación cuando el comprobante no coincide
- Mejorar logging para casos de comprobante no coincidente