### PR TITLE
fix(vta-comprobante): actualizar tablas ERP de fnd a tsr para cobros …

### DIFF
--- a/src/vta-comprobante/cobros.service.spec.ts
+++ b/src/vta-comprobante/cobros.service.spec.ts
@@ -87,3 +87,31 @@ describe('CobrosService tieneCobroFacturaDelPedido', () => {
     expect(cobroFacturaRepo.findOne).not.toHaveBeenCalled();
   });
 });
+
+describe('CobrosService cobrarFactura', () => {
+  it('valida las cuentas contra la tabla tsr_cuenta de la nueva estructura', async () => {
+    const query = jest.fn().mockResolvedValue([]);
+    const dataSource = {
+      transaction: jest.fn(async (callback) => callback({ query })),
+    };
+    const service = new CobrosService(
+      dataSource as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+    );
+
+    await expect(
+      service.cobrarFactura('FX', 'X 00001 00000001', {
+        modalidad: 'CUENTA',
+        medioId: 'BANCOGALICIA',
+      }),
+    ).rejects.toThrow('no existe en tsr_cuenta');
+
+    expect(query).toHaveBeenCalledWith(
+      'SELECT 1 FROM tsr_cuenta WHERE id = ? LIMIT 1',
+      ['BANCOGALICIA'],
+    );
+  });
+});

--- a/src/vta-comprobante/cobros.service.ts
+++ b/src/vta-comprobante/cobros.service.ts
@@ -45,13 +45,13 @@ export class CobrosService {
     return this.dataSource.transaction(async (manager) => {
       if (modalidad === "CUENTA") {
         const cuentaExiste = await manager.query(
-          "SELECT 1 FROM fnd_cuenta WHERE id = ? LIMIT 1",
+          "SELECT 1 FROM tsr_cuenta WHERE id = ? LIMIT 1",
           [medioId],
         );
 
         if (!Array.isArray(cuentaExiste) || cuentaExiste.length === 0) {
           throw new NotFoundException(
-            `CUENTA '${medioId}' no existe en fnd_cuenta. Revisa NAVE_CUENTA_ID.`,
+            `CUENTA '${medioId}' no existe en tsr_cuenta. Revisa NAVE_CUENTA_ID.`,
           );
         }
       }

--- a/src/vta-comprobante/vta-comprobante.service.spec.ts
+++ b/src/vta-comprobante/vta-comprobante.service.spec.ts
@@ -2,6 +2,11 @@ import { VtaComprobanteService } from './vta-comprobante.service';
 import { Pedido } from 'src/pedido/entities/pedido.entity';
 import { VtaComprobante } from './entities/vta-comprobante.entity';
 import { VtaComprobanteItem } from 'src/vta-comprobante-item/entities/vta-comprobante-item.entity';
+import { VtaCobro } from 'src/vta-cobro/entities/vta-cobro.entity';
+import { VtaCobroMedio } from 'src/vta-cobro-medio/entities/vta-cobro-medio.entity';
+import { VtaCobroFactura } from 'src/vta-cobro-factura/entities/vta-cobro-factura.entity';
+import { VtaComprobanteAsiento } from 'src/vta_comprobante_asiento/entities/vta_comprobante_asiento.entity';
+import { CntAsiento } from 'src/cnt-asiento/entities/cnt-asiento.entity';
 
 describe('VtaComprobanteService crearDesdePedido', () => {
   const comprobanteDelete = jest.fn(async () => undefined);
@@ -600,5 +605,77 @@ describe('VtaComprobanteService crearDesdePedido', () => {
       tipo: 'FX',
       comprobante: 'X 00001 00000001',
     });
+  });
+});
+
+describe('VtaComprobanteService eliminarComprobantePorPedido', () => {
+  it('consulta tsr_movimiento_asiento al validar usos externos', async () => {
+    const comprobanteRepo = {
+      findOne: jest.fn().mockResolvedValue({
+        tipo: 'FX',
+        comprobante: 'X 00001 00000001',
+      }),
+      delete: jest.fn(),
+    };
+    const cobroFacturaRepo = {
+      find: jest.fn().mockResolvedValue([]),
+      delete: jest.fn(),
+    };
+    const cobroMedioRepo = {};
+    const cobroRepo = {};
+    const asientoLinkRepo = {
+      find: jest.fn().mockResolvedValue([
+        {
+          tipo: 'FX',
+          comprobante: 'X 00001 00000001',
+          ejercicio: '2026',
+          asiento: 10,
+        },
+      ]),
+      delete: jest.fn(),
+    };
+    const asientoRepo = { delete: jest.fn() };
+    const comprobanteItemRepo = { delete: jest.fn() };
+    const query = jest.fn().mockResolvedValue([
+      {
+        in_cmp_comp: 0,
+        in_cmp_pago: 0,
+        in_tsr: 1,
+        in_vta_cobro: 0,
+      },
+    ]);
+    const repositories = new Map<unknown, unknown>([
+      [VtaComprobante, comprobanteRepo],
+      [VtaCobroFactura, cobroFacturaRepo],
+      [VtaCobroMedio, cobroMedioRepo],
+      [VtaCobro, cobroRepo],
+      [VtaComprobanteAsiento, asientoLinkRepo],
+      [CntAsiento, asientoRepo],
+      [VtaComprobanteItem, comprobanteItemRepo],
+    ]);
+    const manager = {
+      getRepository: jest.fn((target) => repositories.get(target)),
+      query,
+    };
+    const dataSource = {
+      transaction: jest.fn(async (callback) => callback(manager)),
+    };
+    const service = new VtaComprobanteService(
+      dataSource as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+    );
+
+    await service.eliminarComprobantePorPedido(
+      'FX',
+      'X 00001 00000001',
+    );
+
+    const sql = query.mock.calls[0][0] as string;
+    expect(sql).toContain('FROM tsr_movimiento_asiento');
+    expect(sql).not.toContain('fnd_movimiento_asiento');
+    expect(asientoRepo.delete).not.toHaveBeenCalled();
   });
 });

--- a/src/vta-comprobante/vta-comprobante.service.ts
+++ b/src/vta-comprobante/vta-comprobante.service.ts
@@ -117,7 +117,7 @@ export class VtaComprobanteService {
           SELECT
             EXISTS(SELECT 1 FROM cmp_comprobante_asiento WHERE ejercicio = ? AND asiento = ?) AS in_cmp_comp,
             EXISTS(SELECT 1 FROM cmp_pago_asiento WHERE ejercicio = ? AND asiento = ?) AS in_cmp_pago,
-            EXISTS(SELECT 1 FROM fnd_movimiento_asiento WHERE ejercicio = ? AND asiento = ?) AS in_fnd,
+            EXISTS(SELECT 1 FROM tsr_movimiento_asiento WHERE ejercicio = ? AND asiento = ?) AS in_tsr,
             EXISTS(SELECT 1 FROM vta_cobro_asiento WHERE ejercicio = ? AND asiento = ?) AS in_vta_cobro
           `,
           [
@@ -136,7 +136,7 @@ export class VtaComprobanteService {
         const usadoEnOtrosModulos =
           Number(row.in_cmp_comp) > 0 ||
           Number(row.in_cmp_pago) > 0 ||
-          Number(row.in_fnd) > 0 ||
+          Number(row.in_tsr) > 0 ||
           Number(row.in_vta_cobro) > 0;
 
         if (!usadoEnOtrosModulos) {


### PR DESCRIPTION
…y asientos

- En CobrosService.cobrarFactura, validar cuenta en tsr_cuenta en lugar de fnd_cuenta
- En VtaComprobanteService.eliminarComprobantePorPedido, verificar usos en tsr_movimiento_asiento en lugar de fnd_movimiento_asiento
- Renombrar columna in_fnd a in_tsr en la consulta de validación de asientos
- Actualizar tests para reflejar los cambios de tablas