### PR TITLE
fix(pedidos): hacer atómica y flexible la confirmación de stock

### DIFF
--- a/migrations/20260811_add_deposito_reserva_to_pedido_item.sql
+++ b/migrations/20260811_add_deposito_reserva_to_pedido_item.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `pedido_item`
+  ADD COLUMN `deposito_reserva` varchar(20) NULL AFTER `ajuste_porcentaje`;

--- a/src/pedido/entities/pedido-item.entity.ts
+++ b/src/pedido/entities/pedido-item.entity.ts
@@ -4,27 +4,30 @@ import { Pedido } from './pedido.entity';
 
 @Entity('pedido_item')
 export class PedidoItem {
-    @PrimaryGeneratedColumn()
-    id: number;
+  @PrimaryGeneratedColumn()
+  id: number;
 
-    @Column()
-    nombre: string;
+  @Column()
+  nombre: string;
 
-    @Column({ nullable: true })
-    descripcion: string;
+  @Column({ nullable: true })
+  descripcion: string;
 
-    @Column()
-    cantidad: number;
+  @Column()
+  cantidad: number;
 
-    @Column()
-    precio_unitario: number;
+  @Column()
+  precio_unitario: number;
 
-    @Column({ type: 'decimal', precision: 12, scale: 2 })
-    subtotal: number;
+  @Column({ type: 'decimal', precision: 12, scale: 2 })
+  subtotal: number;
 
-    @Column({ type: 'decimal', precision: 5, scale: 2, nullable: true })
-    ajuste_porcentaje: number | null;
+  @Column({ type: 'decimal', precision: 5, scale: 2, nullable: true })
+  ajuste_porcentaje: number | null;
 
-    @ManyToOne(() => Pedido, pedido => pedido.productos)
-    pedido: Pedido;
+  @Column({ type: 'varchar', length: 20, nullable: true })
+  deposito_reserva: string | null;
+
+  @ManyToOne(() => Pedido, (pedido) => pedido.productos)
+  pedido: Pedido;
 }

--- a/src/pedido/pedido-expiration.service.ts
+++ b/src/pedido/pedido-expiration.service.ts
@@ -61,7 +61,11 @@ export class PedidoExpirationService {
         // 1️⃣ Intentar liberar cada producto
         for (const p of pedido.productos) {
           try {
-            await this.existenciaService.liberarStock(p.nombre, p.cantidad);
+            await this.existenciaService.liberarStock(
+              p.nombre,
+              p.cantidad,
+              p.deposito_reserva ?? undefined,
+            );
             liberacionesExitosas.push({
               nombre: p.nombre,
               cantidad: p.cantidad,

--- a/src/pedido/pedido.service.spec.ts
+++ b/src/pedido/pedido.service.spec.ts
@@ -11,6 +11,11 @@ describe('PedidoService recalculo de importes', () => {
     create: jest.fn((pedido) => pedido),
     save: jest.fn(async (pedido) => ({ ...pedido, id: pedido.id ?? 1 })),
     findOne: jest.fn(),
+    manager: {
+      transaction: jest.fn(async (callback) =>
+        callback({ getRepository: () => createRepo }),
+      ),
+    },
   };
   const stkItemRepo = {
     findOne: jest.fn(),
@@ -55,10 +60,28 @@ describe('PedidoService recalculo de importes', () => {
     }),
   };
   const stockService = {
-    reservarStock: jest.fn(async () => undefined),
+    reservarStock: jest.fn(async () => 'DEPOSITO'),
     liberarStock: jest.fn(async () => undefined),
     confirmarStock: jest.fn(async () => 'DEPOSITO'),
     restaurarStockConfirmado: jest.fn(async () => undefined),
+    confirmarStockLote: jest.fn(async (solicitudes) =>
+      solicitudes.map((solicitud) => ({
+        item: solicitud.item,
+        cantidad: solicitud.cantidad,
+        depositoReserva: solicitud.item.startsWith('ENV')
+          ? 'ENV'
+          : (solicitud.deposito ?? 'DEPOSITO'),
+        salidas: [
+          {
+            deposito: solicitud.item.startsWith('ENV')
+              ? 'ENV'
+              : (solicitud.deposito ?? 'DEPOSITO'),
+            cantidad: solicitud.cantidad,
+          },
+        ],
+      })),
+    ),
+    restaurarStockConfirmadoLote: jest.fn(async () => undefined),
   };
   const vtaComprobanteService = {
     crearDesdePedido: jest.fn(),
@@ -85,6 +108,7 @@ describe('PedidoService recalculo de importes', () => {
   };
   const cobrosService = {
     cobrarFactura: jest.fn(async () => undefined),
+    tieneCobroFacturaDelPedido: jest.fn(async () => true),
   };
   const cuponService = {
     validarUsoCupon: jest.fn(async () => undefined),
@@ -1868,7 +1892,11 @@ describe('PedidoService recalculo de importes', () => {
       }),
     ).rejects.toThrow('fallo de comprobante');
 
-    expect(stockService.confirmarStock).toHaveBeenCalledWith('ITEM-1', 1);
+    expect(stockService.confirmarStock).toHaveBeenCalledWith(
+      'ITEM-1',
+      1,
+      undefined,
+    );
     expect(stockService.restaurarStockConfirmado).toHaveBeenCalledWith(
       'ITEM-1',
       1,
@@ -1888,5 +1916,159 @@ describe('PedidoService recalculo de importes', () => {
     ).rejects.toThrow(BadRequestException);
 
     expect(tokenSpy).not.toHaveBeenCalled();
+  });
+
+  it('aprueba una transferencia confirmando el stock como un unico lote', async () => {
+    const pedido = {
+      id: 900,
+      external_id: 'pedido-transferencia',
+      estado: 'PENDIENTE',
+      metodo_pago: 'transfer',
+      comprobante_tipo: 'FX',
+      comprobante_numero: 'X 00001 00000001',
+      codigo_cupon: null,
+      delivery_method: 'pickup',
+      productos: [
+        { nombre: 'ITEM-1', cantidad: 1, deposito_reserva: 'DEPOSITO' },
+        { nombre: 'ITEM-2', cantidad: 2, deposito_reserva: 'DEPOSITO' },
+      ],
+    };
+    createRepo.findOne.mockResolvedValue(pedido);
+
+    const resultado = await service.aprobarTransferencia(pedido.external_id);
+
+    expect(createRepo.findOne).toHaveBeenCalledWith(
+      expect.objectContaining({
+        lock: { mode: 'pessimistic_write' },
+      }),
+    );
+    expect(cobrosService.tieneCobroFacturaDelPedido).toHaveBeenCalledWith(
+      'FX',
+      'X 00001 00000001',
+      pedido,
+    );
+    expect(stockService.confirmarStockLote).toHaveBeenCalledWith([
+      { item: 'ITEM-1', cantidad: 1, deposito: 'DEPOSITO' },
+      { item: 'ITEM-2', cantidad: 2, deposito: 'DEPOSITO' },
+    ]);
+    expect(createRepo.save).toHaveBeenCalledWith(
+      expect.objectContaining({ estado: 'APROBADO' }),
+    );
+    expect(resultado.pedido.estado).toBe('APROBADO');
+  });
+
+  it('no toca stock si el cobro no pertenece al pedido', async () => {
+    const pedido = {
+      id: 901,
+      external_id: 'pedido-cobro-invalido',
+      estado: 'PENDIENTE',
+      metodo_pago: 'transfer',
+      comprobante_tipo: 'FX',
+      comprobante_numero: 'X 00001 00000002',
+      productos: [{ nombre: 'ITEM-1', cantidad: 1 }],
+    };
+    createRepo.findOne.mockResolvedValue(pedido);
+    cobrosService.tieneCobroFacturaDelPedido.mockResolvedValueOnce(false);
+
+    await expect(
+      service.aprobarTransferencia(pedido.external_id),
+    ).rejects.toThrow('no tiene un cobro valido asociado');
+
+    expect(stockService.confirmarStockLote).not.toHaveBeenCalled();
+    expect(createRepo.save).not.toHaveBeenCalled();
+  });
+
+  it('restaura el lote confirmado si falla el guardado del pedido', async () => {
+    const pedido = {
+      id: 902,
+      external_id: 'pedido-save-fallido',
+      estado: 'PENDIENTE',
+      metodo_pago: 'transfer',
+      comprobante_tipo: 'FX',
+      comprobante_numero: 'X 00001 00000003',
+      productos: [{ nombre: 'ITEM-1', cantidad: 1 }],
+    };
+    const confirmaciones = [
+      {
+        item: 'ITEM-1',
+        cantidad: 1,
+        depositoReserva: 'DEPOSITO',
+        salidas: [{ deposito: 'DEPOSITO', cantidad: 1 }],
+      },
+    ];
+    createRepo.findOne.mockResolvedValue(pedido);
+    stockService.confirmarStockLote.mockResolvedValueOnce(confirmaciones);
+    createRepo.save.mockRejectedValueOnce(new Error('fallo guardando pedido'));
+
+    await expect(
+      service.aprobarTransferencia(pedido.external_id),
+    ).rejects.toThrow('fallo guardando pedido');
+
+    expect(stockService.restaurarStockConfirmadoLote).toHaveBeenCalledWith(
+      confirmaciones,
+    );
+  });
+
+  it('es idempotente cuando la transferencia ya esta aprobada', async () => {
+    const pedido = {
+      id: 903,
+      external_id: 'pedido-ya-aprobado',
+      estado: 'APROBADO',
+      metodo_pago: 'transfer',
+      comprobante_tipo: 'FX',
+      comprobante_numero: 'X 00001 00000004',
+      productos: [{ nombre: 'ITEM-1', cantidad: 1 }],
+    };
+    createRepo.findOne.mockResolvedValue(pedido);
+
+    await expect(
+      service.aprobarTransferencia(pedido.external_id),
+    ).resolves.toMatchObject({
+      pedido,
+      comprobante: {
+        tipo: 'FX',
+        comprobante: 'X 00001 00000004',
+      },
+    });
+
+    expect(cobrosService.tieneCobroFacturaDelPedido).not.toHaveBeenCalled();
+    expect(stockService.confirmarStockLote).not.toHaveBeenCalled();
+    expect(createRepo.save).not.toHaveBeenCalled();
+  });
+
+  it('rechaza una segunda aprobacion concurrente en la misma instancia', async () => {
+    const pedido = {
+      id: 904,
+      external_id: 'pedido-concurrente',
+      estado: 'PENDIENTE',
+      metodo_pago: 'transfer',
+      comprobante_tipo: 'FX',
+      comprobante_numero: 'X 00001 00000005',
+      codigo_cupon: null,
+      delivery_method: 'pickup',
+      productos: [{ nombre: 'ITEM-1', cantidad: 1 }],
+    };
+    createRepo.findOne.mockResolvedValue(pedido);
+
+    let resolverCobro: (value: boolean) => void = () => undefined;
+    cobrosService.tieneCobroFacturaDelPedido.mockImplementationOnce(
+      () =>
+        new Promise<boolean>((resolve) => {
+          resolverCobro = resolve;
+        }),
+    );
+
+    const primeraAprobacion = service.aprobarTransferencia(pedido.external_id);
+    await Promise.resolve();
+
+    await expect(
+      service.aprobarTransferencia(pedido.external_id),
+    ).rejects.toThrow('ya se esta aprobando en esta instancia');
+
+    resolverCobro(true);
+    await expect(primeraAprobacion).resolves.toMatchObject({
+      pedido: expect.objectContaining({ estado: 'APROBADO' }),
+    });
+    expect(stockService.confirmarStockLote).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/pedido/pedido.service.ts
+++ b/src/pedido/pedido.service.ts
@@ -15,7 +15,10 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Pedido } from './entities/pedido.entity';
 import { Brackets, Repository } from 'typeorm';
 import { CreatePedidoDto } from './dto/create-pedido.dto';
-import { StkExistenciaService } from 'src/stk-existencia/stk-existencia.service';
+import {
+  StkExistenciaService,
+  StockConfirmado,
+} from 'src/stk-existencia/stk-existencia.service';
 import { StkItem } from 'src/stk-item/entities/stk-item.entity';
 import { StkAtributo } from 'src/stk-item/entities/stk-atributo.entity';
 import { StkAtributoNodo } from 'src/stk-item/entities/stk-atributo-nodo.entity';
@@ -88,6 +91,7 @@ interface PedidoCuponResolucion {
 @Injectable()
 export class PedidoService {
   private readonly logger = new Logger(PedidoService.name);
+  private readonly transferenciasEnAprobacion = new Set<string>();
 
   constructor(
     @InjectRepository(Pedido, 'back') // 👈 Base de datos propia
@@ -303,8 +307,34 @@ export class PedidoService {
       factura_iva_importe: facturaIvaImporte,
     });
 
-    for (const p of productosValidados) {
-      await this.stockService.reservarStock(p.nombre, p.cantidad);
+    const reservasRealizadas: PedidoItem[] = [];
+    try {
+      for (const p of productosValidados) {
+        p.deposito_reserva = await this.stockService.reservarStock(
+          p.nombre,
+          p.cantidad,
+        );
+        reservasRealizadas.push(p);
+      }
+    } catch (error) {
+      for (const reservado of reservasRealizadas.reverse()) {
+        try {
+          await this.stockService.liberarStock(
+            reservado.nombre,
+            reservado.cantidad,
+            reservado.deposito_reserva ?? undefined,
+          );
+        } catch (rollbackError) {
+          this.logger.error(
+            `Error liberando reserva incompleta de ${reservado.nombre}: ${
+              rollbackError instanceof Error
+                ? rollbackError.message
+                : String(rollbackError)
+            }`,
+          );
+        }
+      }
+      throw error;
     }
 
     const externalId = uuidv4().replace(/-/g, '');
@@ -351,7 +381,29 @@ export class PedidoService {
       factura_iva_importe: facturaIvaImporte,
     });
 
-    const pedidoGuardado = await this.pedidoRepo.save(pedido);
+    let pedidoGuardado: Pedido;
+    try {
+      pedidoGuardado = await this.pedidoRepo.save(pedido);
+    } catch (error) {
+      for (const reservado of reservasRealizadas.reverse()) {
+        try {
+          await this.stockService.liberarStock(
+            reservado.nombre,
+            reservado.cantidad,
+            reservado.deposito_reserva ?? undefined,
+          );
+        } catch (rollbackError) {
+          this.logger.error(
+            `Error liberando reserva de ${reservado.nombre} luego de fallar el guardado del pedido: ${
+              rollbackError instanceof Error
+                ? rollbackError.message
+                : String(rollbackError)
+            }`,
+          );
+        }
+      }
+      throw error;
+    }
 
     // Para transferencias, generar comprobante pendiente sin cobro
     if (pedidoGuardado.metodo_pago === 'transfer') {
@@ -364,7 +416,11 @@ export class PedidoService {
       } catch (err) {
         for (const p of productosValidados) {
           try {
-            await this.stockService.liberarStock(p.nombre, p.cantidad);
+            await this.stockService.liberarStock(
+              p.nombre,
+              p.cantidad,
+              p.deposito_reserva ?? undefined,
+            );
           } catch (e) {
             console.error(
               `Error liberando stock de ${p.nombre}:`,
@@ -427,7 +483,11 @@ export class PedidoService {
       // Rollback: liberar stock y marcar pedido como cancelado
       for (const p of productosValidados) {
         try {
-          await this.stockService.liberarStock(p.nombre, p.cantidad);
+          await this.stockService.liberarStock(
+            p.nombre,
+            p.cantidad,
+            p.deposito_reserva ?? undefined,
+          );
         } catch (e) {
           // log y continuar intentando liberar el resto
           console.error(
@@ -791,7 +851,10 @@ export class PedidoService {
             );
             for (const p of pedido.productos) {
               try {
-                await this.stockService.reservarStock(p.nombre, p.cantidad);
+                p.deposito_reserva = await this.stockService.reservarStock(
+                  p.nombre,
+                  p.cantidad,
+                );
               } catch (err) {
                 console.error(
                   `❌ No se pudo re-reservar stock para ${p.nombre}`,
@@ -811,6 +874,7 @@ export class PedidoService {
             const deposito = await this.stockService.confirmarStock(
               p.nombre,
               p.cantidad,
+              p.deposito_reserva ?? undefined,
             );
             stockConfirmado.push({
               item: p.nombre,
@@ -927,7 +991,11 @@ export class PedidoService {
       case 'REFUNDED':
         pedido.estado = 'CANCELADO';
         for (const p of pedido.productos) {
-          await this.stockService.liberarStock(p.nombre, p.cantidad);
+          await this.stockService.liberarStock(
+            p.nombre,
+            p.cantidad,
+            p.deposito_reserva ?? undefined,
+          );
         }
         await this.eliminarComprobanteSiExiste(pedido);
         try {
@@ -1099,6 +1167,7 @@ export class PedidoService {
         await this.stockService.liberarStock(
           producto.nombre,
           producto.cantidad,
+          producto.deposito_reserva ?? undefined,
         );
       } catch (err) {
         console.error(`❌ Error liberando stock de ${producto.nombre}:`, err);
@@ -1125,74 +1194,137 @@ export class PedidoService {
   async aprobarTransferencia(
     externalId: string,
   ): Promise<{ pedido: Pedido; comprobante: any }> {
-    const pedido = await this.pedidoRepo.findOne({
-      where: { external_id: externalId },
-      relations: ['productos'],
-    });
-
-    if (!pedido) {
-      throw new NotFoundException(`Pedido ${externalId} no encontrado`);
-    }
-
-    if (pedido.metodo_pago !== 'transfer') {
-      throw new BadRequestException(
-        `Pedido ${externalId} no es de tipo transferencia`,
-      );
-    }
-
-    if (pedido.estado !== 'PENDIENTE') {
+    if (this.transferenciasEnAprobacion.has(externalId)) {
       throw new ConflictException(
-        `Pedido ${externalId} ya fue procesado (estado: ${pedido.estado})`,
+        `Pedido ${externalId} ya se esta aprobando en esta instancia`,
       );
     }
 
-    // Verificar y confirmar stock
-    for (const p of pedido.productos) {
-      try {
-        await this.stockService.confirmarStock(p.nombre, p.cantidad);
-      } catch (err) {
-        console.error(`❌ No se pudo confirmar stock para ${p.nombre}`, err);
-        throw new ConflictException(
-          `Stock insuficiente para ${p.nombre}. El pedido no puede ser aprobado.`,
+    this.transferenciasEnAprobacion.add(externalId);
+
+    let pedido!: Pedido;
+    let comprobanteCreado!: { tipo: string; comprobante: string };
+    let aprobacionNueva = false;
+
+    try {
+      await this.pedidoRepo.manager.transaction(async (manager) => {
+        const pedidoRepo = manager.getRepository(Pedido);
+        const pedidoEncontrado = await pedidoRepo.findOne({
+          where: { external_id: externalId },
+          relations: ['productos'],
+          lock: { mode: 'pessimistic_write' },
+        });
+
+        if (!pedidoEncontrado) {
+          throw new NotFoundException(`Pedido ${externalId} no encontrado`);
+        }
+
+        pedido = pedidoEncontrado;
+
+        if (pedido.metodo_pago !== 'transfer') {
+          throw new BadRequestException(
+            `Pedido ${externalId} no es de tipo transferencia`,
+          );
+        }
+
+        if (pedido.estado === 'APROBADO') {
+          if (!pedido.comprobante_tipo || !pedido.comprobante_numero) {
+            throw new ConflictException(
+              `Pedido ${externalId} esta aprobado pero no tiene comprobante asociado`,
+            );
+          }
+
+          comprobanteCreado = {
+            tipo: pedido.comprobante_tipo,
+            comprobante: pedido.comprobante_numero,
+          };
+          return;
+        }
+
+        if (pedido.estado !== 'PENDIENTE') {
+          throw new ConflictException(
+            `Pedido ${externalId} no puede aprobarse (estado: ${pedido.estado})`,
+          );
+        }
+
+        if (!pedido.productos?.length) {
+          throw new BadRequestException(
+            `Pedido ${externalId} no tiene productos para confirmar`,
+          );
+        }
+
+        if (!pedido.comprobante_tipo || !pedido.comprobante_numero) {
+          throw new ConflictException(
+            `Pedido ${externalId} no tiene comprobante asociado`,
+          );
+        }
+
+        const tieneCobro = await this.cobrosService.tieneCobroFacturaDelPedido(
+          pedido.comprobante_tipo,
+          pedido.comprobante_numero,
+          pedido,
         );
+        if (!tieneCobro) {
+          throw new ConflictException(
+            `Pedido ${externalId} no tiene un cobro valido asociado`,
+          );
+        }
+
+        comprobanteCreado = {
+          tipo: pedido.comprobante_tipo,
+          comprobante: pedido.comprobante_numero,
+        };
+
+        let stockConfirmado: StockConfirmado[] = [];
+        try {
+          stockConfirmado = await this.stockService.confirmarStockLote(
+            pedido.productos.map((producto) => ({
+              item: producto.nombre,
+              cantidad: producto.cantidad,
+              deposito: producto.deposito_reserva ?? undefined,
+            })),
+          );
+
+          pedido.estado = 'APROBADO';
+          pedido.aprobado = new Date();
+          pedido = await pedidoRepo.save(pedido);
+          aprobacionNueva = true;
+        } catch (error) {
+          if (stockConfirmado.length) {
+            try {
+              await this.stockService.restaurarStockConfirmadoLote(
+                stockConfirmado,
+              );
+            } catch (rollbackError) {
+              this.logger.error(
+                `[${externalId}] Fallo critico restaurando stock luego de una aprobacion fallida`,
+                rollbackError instanceof Error
+                  ? rollbackError.stack
+                  : String(rollbackError),
+              );
+              throw new InternalServerErrorException(
+                `Pedido ${externalId} requiere reconciliacion manual de stock`,
+              );
+            }
+          }
+
+          this.logger.error(
+            `[${externalId}] No se pudo completar la aprobacion de transferencia: ${
+              error instanceof Error ? error.message : String(error)
+            }`,
+          );
+          throw error;
+        }
+      });
+
+      if (!aprobacionNueva) {
+        return { pedido, comprobante: comprobanteCreado };
       }
+
+      await this.registrarUsoCuponSiCorresponde(pedido);
+    } finally {
+      this.transferenciasEnAprobacion.delete(externalId);
     }
-
-    // Actualizar estado
-    pedido.estado = 'APROBADO';
-    pedido.aprobado = new Date();
-
-    // Crear comprobante con método de pago 'transfer'
-    let comprobanteCreado: { tipo: string; comprobante: string };
-    if (pedido.comprobante_tipo && pedido.comprobante_numero) {
-      comprobanteCreado = {
-        tipo: pedido.comprobante_tipo,
-        comprobante: pedido.comprobante_numero,
-      };
-    } else {
-      try {
-        const comp = await this.vtaComprobanteService.crearDesdePedido(pedido);
-        comprobanteCreado = { tipo: comp.tipo, comprobante: comp.comprobante };
-        pedido.comprobante_tipo = comp.tipo;
-        pedido.comprobante_numero = comp.comprobante;
-        console.log(
-          `🧾 Comprobante generado para pedido transferencia ${pedido.external_id}:`,
-          comprobanteCreado,
-        );
-      } catch (err) {
-        console.error(
-          `❌ Error al generar comprobante para pedido ${pedido.external_id}:`,
-          err,
-        );
-        throw err;
-      }
-    }
-
-    // NO generar cobro para transferencias
-
-    // Guardar pedido actualizado
-    await this.pedidoRepo.save(pedido);
-    await this.registrarUsoCuponSiCorresponde(pedido);
 
     // Notificaciones no críticas
     try {
@@ -1616,6 +1748,7 @@ export class PedidoService {
       precio_unitario: producto.precio_unitario,
       subtotal: producto.subtotal,
       ajuste_porcentaje: producto.ajuste_porcentaje,
+      deposito_reserva: null,
     } as PedidoItem;
   }
 

--- a/src/stk-existencia/stk-existencia.service.spec.ts
+++ b/src/stk-existencia/stk-existencia.service.spec.ts
@@ -3,13 +3,20 @@ import { StkExistenciaService } from './stk-existencia.service';
 describe('StkExistenciaService', () => {
   const repo = {
     findOne: jest.fn(),
+    find: jest.fn(),
     save: jest.fn(async (value) => value),
+    manager: {
+      transaction: jest.fn(),
+    },
   };
 
   let service: StkExistenciaService;
 
   beforeEach(() => {
     jest.clearAllMocks();
+    repo.manager.transaction.mockImplementation(async (callback) =>
+      callback({ getRepository: () => repo }),
+    );
     service = new StkExistenciaService(repo as any);
   });
 
@@ -47,6 +54,176 @@ describe('StkExistenciaService', () => {
   it('ignora los items virtuales de envio al restaurar', async () => {
     await service.restaurarStockConfirmado('ENV-DELIVERY', 1, 'ENV');
     expect(repo.findOne).not.toHaveBeenCalled();
+    expect(repo.save).not.toHaveBeenCalled();
+  });
+
+  it('valida el lote completo antes de modificar existencias', async () => {
+    const itemValido = {
+      item: 'ITEM-1',
+      deposito: 'DEPOSITO',
+      cantidad: '10',
+      comprometido: '1',
+    };
+    const itemSinStockFisico = {
+      item: 'ITEM-2',
+      deposito: 'DEPOSITO',
+      cantidad: '0',
+      comprometido: '1',
+    };
+    repo.find.mockImplementation(async ({ where }) =>
+      where.item === 'ITEM-1' ? [itemValido] : [itemSinStockFisico],
+    );
+
+    await expect(
+      service.confirmarStockLote([
+        { item: 'ITEM-1', cantidad: 1 },
+        { item: 'ITEM-2', cantidad: 1 },
+      ]),
+    ).rejects.toThrow(
+      'Stock fisico insuficiente para ITEM-2. Utilizable entre depositos: 0, Solicitado: 1, Reserva en DEPOSITO: 1',
+    );
+
+    expect(itemValido).toMatchObject({
+      cantidad: '10',
+      comprometido: '1',
+    });
+    expect(repo.save).not.toHaveBeenCalled();
+  });
+
+  it('agrupa productos repetidos y confirma el lote en una transaccion', async () => {
+    const existencia = {
+      item: 'ITEM-1',
+      deposito: 'DEPOSITO',
+      cantidad: '10',
+      comprometido: '3',
+    };
+    repo.find.mockResolvedValue([existencia]);
+
+    await expect(
+      service.confirmarStockLote([
+        { item: 'ITEM-1', cantidad: 1 },
+        { item: 'ITEM-1', cantidad: 2 },
+      ]),
+    ).resolves.toEqual([
+      {
+        item: 'ITEM-1',
+        cantidad: 3,
+        depositoReserva: 'DEPOSITO',
+        salidas: [{ deposito: 'DEPOSITO', cantidad: 3 }],
+      },
+    ]);
+
+    expect(existencia).toMatchObject({
+      cantidad: '7',
+      comprometido: '0',
+    });
+    expect(repo.save).toHaveBeenCalledTimes(1);
+  });
+
+  it('restaura un lote confirmado de forma transaccional', async () => {
+    const existencia = {
+      item: 'ITEM-1',
+      deposito: 'DEPOSITO',
+      cantidad: '7',
+      comprometido: '0',
+    };
+    repo.find.mockResolvedValue([existencia]);
+
+    await service.restaurarStockConfirmadoLote([
+      {
+        item: 'ITEM-1',
+        cantidad: 3,
+        depositoReserva: 'DEPOSITO',
+        salidas: [{ deposito: 'DEPOSITO', cantidad: 3 }],
+      },
+    ]);
+
+    expect(existencia).toMatchObject({
+      cantidad: '10',
+      comprometido: '3',
+    });
+    expect(repo.save).toHaveBeenCalledWith([existencia]);
+  });
+
+  it('mantiene la reserva original y permite sacar stock de otros depositos', async () => {
+    const garage = {
+      item: 'ITEM-1',
+      deposito: 'GARAGE',
+      cantidad: '0',
+      comprometido: '2',
+    };
+    const local = {
+      item: 'ITEM-1',
+      deposito: 'LOCAL',
+      cantidad: '1',
+      comprometido: '0',
+    };
+    const deposito = {
+      item: 'ITEM-1',
+      deposito: 'DEPOSITO',
+      cantidad: '1',
+      comprometido: '0',
+    };
+    repo.find.mockResolvedValue([garage, local, deposito]);
+
+    const confirmaciones = await service.confirmarStockLote([
+      { item: 'ITEM-1', cantidad: 2, deposito: 'GARAGE' },
+    ]);
+
+    expect(confirmaciones).toEqual([
+      {
+        item: 'ITEM-1',
+        cantidad: 2,
+        depositoReserva: 'GARAGE',
+        salidas: [
+          { deposito: 'LOCAL', cantidad: 1 },
+          { deposito: 'DEPOSITO', cantidad: 1 },
+        ],
+      },
+    ]);
+
+    expect(garage).toMatchObject({ cantidad: '0', comprometido: '0' });
+    expect(local.cantidad).toBe('0');
+    expect(deposito.cantidad).toBe('0');
+
+    await service.restaurarStockConfirmadoLote(confirmaciones);
+
+    expect(garage).toMatchObject({ cantidad: '0', comprometido: '2' });
+    expect(local.cantidad).toBe('1');
+    expect(deposito.cantidad).toBe('1');
+  });
+
+  it('no asigna dos veces el mismo stock fisico a reservas distintas', async () => {
+    const reservaA = {
+      item: 'ITEM-1',
+      deposito: 'RESERVA-A',
+      cantidad: '0',
+      comprometido: '1',
+    };
+    const reservaB = {
+      item: 'ITEM-1',
+      deposito: 'RESERVA-B',
+      cantidad: '0',
+      comprometido: '1',
+    };
+    const salida = {
+      item: 'ITEM-1',
+      deposito: 'LOCAL',
+      cantidad: '1',
+      comprometido: '0',
+    };
+    repo.find.mockResolvedValue([reservaA, reservaB, salida]);
+
+    await expect(
+      service.confirmarStockLote([
+        { item: 'ITEM-1', cantidad: 1, deposito: 'RESERVA-A' },
+        { item: 'ITEM-1', cantidad: 1, deposito: 'RESERVA-B' },
+      ]),
+    ).rejects.toThrow('Stock fisico insuficiente para ITEM-1');
+
+    expect(reservaA.comprometido).toBe('1');
+    expect(reservaB.comprometido).toBe('1');
+    expect(salida.cantidad).toBe('1');
     expect(repo.save).not.toHaveBeenCalled();
   });
 });

--- a/src/stk-existencia/stk-existencia.service.ts
+++ b/src/stk-existencia/stk-existencia.service.ts
@@ -9,6 +9,24 @@ import { StkExistencia } from './entities/stk-existencia.entity';
 import { CreateStkExistenciaDto } from './dto/create-stk-existencia.dto';
 import { UpdateStkExistenciaDto } from './dto/update-stk-existencia.dto';
 
+export interface StockSolicitud {
+  item: string;
+  cantidad: number;
+  deposito?: string;
+}
+
+export interface StockSalida {
+  deposito: string;
+  cantidad: number;
+}
+
+export interface StockConfirmado {
+  item: string;
+  cantidad: number;
+  depositoReserva: string;
+  salidas: StockSalida[];
+}
+
 @Injectable()
 export class StkExistenciaService {
   constructor(
@@ -180,6 +198,189 @@ export class StkExistenciaService {
   }
 
   /**
+   * Confirma todas las reservas como una unica operacion. Las filas quedan
+   * bloqueadas hasta validar y guardar el lote completo; si una linea falla,
+   * la transaccion revierte cualquier cambio anterior.
+   */
+  async confirmarStockLote(
+    solicitudes: StockSolicitud[],
+  ): Promise<StockConfirmado[]> {
+    const agrupadas = this.agruparSolicitudes(solicitudes);
+
+    return this.stkExistenciaRepository.manager.transaction(async (manager) => {
+      const repo = manager.getRepository(StkExistencia);
+      const confirmaciones: Array<{
+        existencia: StkExistencia;
+        item: string;
+        cantidad: number;
+        depositoReserva: string;
+        salidas: Array<{
+          existencia: StkExistencia;
+          deposito: string;
+          cantidad: number;
+        }>;
+      }> = [];
+      const virtuales: StockConfirmado[] = [];
+      const compromisoPlanificado = new Map<StkExistencia, number>();
+      const salidaPlanificada = new Map<StkExistencia, number>();
+
+      for (const solicitud of agrupadas) {
+        if (solicitud.item.startsWith('ENV')) {
+          virtuales.push({
+            item: solicitud.item,
+            cantidad: solicitud.cantidad,
+            depositoReserva: 'ENV',
+            salidas: [{ deposito: 'ENV', cantidad: solicitud.cantidad }],
+          });
+          continue;
+        }
+
+        const existencias = await repo.find({
+          where: { item: solicitud.item },
+          lock: { mode: 'pessimistic_write' },
+        });
+
+        if (!existencias.length) {
+          throw new NotFoundException(
+            `Stock no encontrado para ${solicitud.item}${
+              solicitud.deposito ? ` en ${solicitud.deposito}` : ''
+            }`,
+          );
+        }
+
+        const reservaPreferida = solicitud.deposito
+          ? existencias.find((row) => row.deposito === solicitud.deposito)
+          : undefined;
+        const compromisoDisponible = (row: StkExistencia) =>
+          Number(row.comprometido || 0) - (compromisoPlanificado.get(row) ?? 0);
+        const existencia =
+          (reservaPreferida &&
+          compromisoDisponible(reservaPreferida) >= solicitud.cantidad
+            ? reservaPreferida
+            : undefined) ??
+          existencias
+            .filter((row) => compromisoDisponible(row) >= solicitud.cantidad)
+            .sort(
+              (a, b) => compromisoDisponible(b) - compromisoDisponible(a),
+            )[0];
+
+        if (!existencia) {
+          const compromisoMaximo = Math.max(
+            0,
+            ...existencias.map((row) => compromisoDisponible(row)),
+          );
+          throw new ConflictException(
+            `Reserva insuficiente para ${solicitud.item}. Comprometido maximo: ${compromisoMaximo}, Solicitado: ${solicitud.cantidad}`,
+          );
+        }
+
+        const comprometido = compromisoDisponible(existencia);
+        if (comprometido < solicitud.cantidad) {
+          throw new ConflictException(
+            `Reserva insuficiente para ${solicitud.item} en ${existencia.deposito}. Comprometido: ${comprometido}, Solicitado: ${solicitud.cantidad}`,
+          );
+        }
+
+        const obtenerStockUtilizable = (row: StkExistencia) => {
+          const cantidadRestante =
+            Number(row.cantidad || 0) - (salidaPlanificada.get(row) ?? 0);
+          const compromisoRestante =
+            Number(row.comprometido || 0) -
+            (compromisoPlanificado.get(row) ?? 0) -
+            (row === existencia ? solicitud.cantidad : 0);
+          return Math.max(0, cantidadRestante - compromisoRestante);
+        };
+        const candidatosSalida = [...existencias].sort((a, b) => {
+          if (a.deposito === existencia.deposito) return -1;
+          if (b.deposito === existencia.deposito) return 1;
+          return obtenerStockUtilizable(b) - obtenerStockUtilizable(a);
+        });
+        const salidas: Array<{
+          existencia: StkExistencia;
+          deposito: string;
+          cantidad: number;
+        }> = [];
+        let cantidadPendiente = solicitud.cantidad;
+
+        for (const candidato of candidatosSalida) {
+          if (cantidadPendiente <= 0) break;
+
+          const utilizable = obtenerStockUtilizable(candidato);
+          const cantidadSalida = Math.min(utilizable, cantidadPendiente);
+          if (cantidadSalida <= 0) continue;
+
+          salidas.push({
+            existencia: candidato,
+            deposito: candidato.deposito,
+            cantidad: cantidadSalida,
+          });
+          cantidadPendiente -= cantidadSalida;
+        }
+
+        if (cantidadPendiente > 0) {
+          const stockUtilizable = solicitud.cantidad - cantidadPendiente;
+          throw new ConflictException(
+            `Stock fisico insuficiente para ${solicitud.item}. Utilizable entre depositos: ${stockUtilizable}, Solicitado: ${solicitud.cantidad}, Reserva en ${existencia.deposito}: ${comprometido}`,
+          );
+        }
+
+        confirmaciones.push({
+          existencia,
+          item: solicitud.item,
+          cantidad: solicitud.cantidad,
+          depositoReserva: existencia.deposito,
+          salidas,
+        });
+        compromisoPlanificado.set(
+          existencia,
+          (compromisoPlanificado.get(existencia) ?? 0) + solicitud.cantidad,
+        );
+        for (const salida of salidas) {
+          salidaPlanificada.set(
+            salida.existencia,
+            (salidaPlanificada.get(salida.existencia) ?? 0) + salida.cantidad,
+          );
+        }
+      }
+
+      const existenciasModificadas = new Set<StkExistencia>();
+      for (const confirmacion of confirmaciones) {
+        const comprometido = Number(confirmacion.existencia.comprometido || 0);
+        confirmacion.existencia.comprometido = (
+          comprometido - confirmacion.cantidad
+        ).toString();
+        existenciasModificadas.add(confirmacion.existencia);
+
+        for (const salida of confirmacion.salidas) {
+          salida.existencia.cantidad = (
+            Number(salida.existencia.cantidad || 0) - salida.cantidad
+          ).toString();
+          existenciasModificadas.add(salida.existencia);
+        }
+      }
+
+      if (existenciasModificadas.size) {
+        await repo.save([...existenciasModificadas]);
+      }
+
+      return [
+        ...confirmaciones.map(
+          ({ item, cantidad, depositoReserva, salidas }) => ({
+            item,
+            cantidad,
+            depositoReserva,
+            salidas: salidas.map(({ deposito, cantidad: salidaCantidad }) => ({
+              deposito,
+              cantidad: salidaCantidad,
+            })),
+          }),
+        ),
+        ...virtuales,
+      ];
+    });
+  }
+
+  /**
    * Compensa una confirmacion cuando falla una operacion critica posterior.
    * Repone tanto la existencia como la reserva que habia antes de confirmar.
    */
@@ -207,6 +408,91 @@ export class StkExistenciaService {
     ).toString();
 
     await this.stkExistenciaRepository.save(existencia);
+  }
+
+  async restaurarStockConfirmadoLote(
+    confirmaciones: StockConfirmado[],
+  ): Promise<void> {
+    await this.stkExistenciaRepository.manager.transaction(async (manager) => {
+      const repo = manager.getRepository(StkExistencia);
+      const existenciasRestauradas = new Set<StkExistencia>();
+
+      for (const confirmacion of confirmaciones) {
+        if (
+          confirmacion.item.startsWith('ENV') ||
+          confirmacion.depositoReserva === 'ENV'
+        ) {
+          continue;
+        }
+
+        const existencias = await repo.find({
+          where: { item: confirmacion.item },
+          lock: { mode: 'pessimistic_write' },
+        });
+        const existenciaReserva = existencias.find(
+          (row) => row.deposito === confirmacion.depositoReserva,
+        );
+        if (!existenciaReserva) {
+          throw new NotFoundException(
+            `No se pudo restaurar la reserva de ${confirmacion.item} en ${confirmacion.depositoReserva}`,
+          );
+        }
+
+        existenciaReserva.comprometido = (
+          Number(existenciaReserva.comprometido || 0) + confirmacion.cantidad
+        ).toString();
+        existenciasRestauradas.add(existenciaReserva);
+
+        for (const salida of confirmacion.salidas) {
+          if (salida.deposito === 'ENV') continue;
+          const existenciaSalida = existencias.find(
+            (row) => row.deposito === salida.deposito,
+          );
+          if (!existenciaSalida) {
+            throw new NotFoundException(
+              `No se pudo restaurar la salida de ${confirmacion.item} en ${salida.deposito}`,
+            );
+          }
+
+          existenciaSalida.cantidad = (
+            Number(existenciaSalida.cantidad || 0) + salida.cantidad
+          ).toString();
+          existenciasRestauradas.add(existenciaSalida);
+        }
+      }
+
+      if (existenciasRestauradas.size) {
+        await repo.save([...existenciasRestauradas]);
+      }
+    });
+  }
+
+  private agruparSolicitudes(solicitudes: StockSolicitud[]): StockSolicitud[] {
+    const agrupadas = new Map<string, StockSolicitud>();
+
+    for (const solicitud of solicitudes) {
+      const cantidad = Number(solicitud.cantidad);
+      if (!Number.isFinite(cantidad) || cantidad <= 0) {
+        throw new ConflictException(
+          `Cantidad invalida para ${solicitud.item}: ${solicitud.cantidad}`,
+        );
+      }
+
+      const key = `${solicitud.item}\u0000${solicitud.deposito ?? ''}`;
+      const existente = agrupadas.get(key);
+      if (existente) {
+        existente.cantidad += cantidad;
+      } else {
+        agrupadas.set(key, { ...solicitud, cantidad });
+      }
+    }
+
+    return [...agrupadas.values()].sort((a, b) => {
+      const itemComparison = a.item.localeCompare(b.item);
+      return (
+        itemComparison || (a.deposito ?? '').localeCompare(b.deposito ?? '')
+      );
+    });
   }
 
   async liberarStock(item: string, cantidad: number, deposito?: string) {


### PR DESCRIPTION
Valida cobros, evita aprobaciones concurrentes y confirma el stock por lote. Permite utilizar múltiples depósitos, conserva el origen de la reserva y compensa los movimientos ante fallos. Incluye la migración de deposito_reserva y pruebas de regresión.